### PR TITLE
feat: HTML tree builder, DOM types, HtmlParser facade

### DIFF
--- a/src/EggPdf.Html/Dom/HtmlNode.cs
+++ b/src/EggPdf.Html/Dom/HtmlNode.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+
+namespace EggPdf.Html.Dom;
+
+/// <summary>Base class for all DOM nodes.</summary>
+public abstract class HtmlNode
+{
+    public HtmlNode? Parent { get; internal set; }
+    public List<HtmlNode> ChildNodes { get; } = new();
+
+    public void AppendChild(HtmlNode child)
+    {
+        child.Parent = this;
+        ChildNodes.Add(child);
+    }
+
+    public void InsertBefore(HtmlNode child, HtmlNode? reference)
+    {
+        child.Parent = this;
+        if (reference == null)
+        {
+            ChildNodes.Add(child);
+            return;
+        }
+        int index = ChildNodes.IndexOf(reference);
+        if (index >= 0)
+            ChildNodes.Insert(index, child);
+        else
+            ChildNodes.Add(child);
+    }
+
+    public void RemoveChild(HtmlNode child)
+    {
+        ChildNodes.Remove(child);
+        child.Parent = null;
+    }
+}
+
+/// <summary>The root document node.</summary>
+public class HtmlDocument : HtmlNode
+{
+    public HtmlElement? DocumentElement =>
+        ChildNodes.Find(n => n is HtmlElement e && e.TagName == "html") as HtmlElement;
+
+    public HtmlElement? Head =>
+        DocumentElement?.ChildNodes.Find(n => n is HtmlElement e && e.TagName == "head") as HtmlElement;
+
+    public HtmlElement? Body =>
+        DocumentElement?.ChildNodes.Find(n => n is HtmlElement e && e.TagName == "body") as HtmlElement;
+}
+
+/// <summary>An HTML element with tag name and attributes.</summary>
+public class HtmlElement : HtmlNode
+{
+    public string TagName { get; }
+    private readonly Dictionary<string, string> _attributes = new(StringComparer.OrdinalIgnoreCase);
+
+    public HtmlElement(string tagName)
+    {
+        TagName = tagName.ToLowerInvariant();
+    }
+
+    public string? Id => GetAttribute("id");
+
+    public string[] ClassList
+    {
+        get
+        {
+            var cls = GetAttribute("class");
+            if (string.IsNullOrWhiteSpace(cls)) return Array.Empty<string>();
+            return cls.Split(new[] { ' ', '\t', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+
+    public string? GetAttribute(string name)
+        => _attributes.TryGetValue(name, out var val) ? val : null;
+
+    public bool HasAttribute(string name)
+        => _attributes.ContainsKey(name);
+
+    public void SetAttribute(string name, string value)
+    {
+        // Per HTML5 spec, first attribute wins on duplicates
+        if (!_attributes.ContainsKey(name))
+            _attributes[name] = value;
+    }
+
+    public IEnumerable<KeyValuePair<string, string>> Attributes => _attributes;
+}
+
+/// <summary>A text content node.</summary>
+public class HtmlTextNode : HtmlNode
+{
+    public string Data { get; set; }
+
+    public HtmlTextNode(string data)
+    {
+        Data = data;
+    }
+}
+
+/// <summary>An HTML comment node.</summary>
+public class HtmlComment : HtmlNode
+{
+    public string Data { get; }
+
+    public HtmlComment(string data)
+    {
+        Data = data;
+    }
+}
+
+/// <summary>A doctype node.</summary>
+public class HtmlDocumentType : HtmlNode
+{
+    public string Name { get; }
+    public string? PublicId { get; }
+    public string? SystemId { get; }
+
+    public HtmlDocumentType(string name, string? publicId = null, string? systemId = null)
+    {
+        Name = name;
+        PublicId = publicId;
+        SystemId = systemId;
+    }
+}

--- a/src/EggPdf.Html/HtmlParser.cs
+++ b/src/EggPdf.Html/HtmlParser.cs
@@ -1,0 +1,22 @@
+using EggPdf.Html.Dom;
+
+namespace EggPdf.Html;
+
+/// <summary>
+/// Parses an HTML string into a DOM tree.
+/// Infallible: never throws on any input. Always produces a valid HtmlDocument.
+/// </summary>
+public static class HtmlParser
+{
+    /// <summary>
+    /// Parse an HTML string into a DOM tree.
+    /// </summary>
+    /// <param name="html">The HTML string to parse. Can be null, empty, or malformed.</param>
+    /// <returns>A valid HtmlDocument with at minimum html, head, and body elements.</returns>
+    public static HtmlDocument Parse(string html)
+    {
+        var tokenizer = new HtmlTokenizer(html ?? "");
+        var builder = new HtmlTreeBuilder();
+        return builder.Build(tokenizer);
+    }
+}

--- a/src/EggPdf.Html/HtmlTreeBuilder.cs
+++ b/src/EggPdf.Html/HtmlTreeBuilder.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EggPdf.Html.Dom;
+
+namespace EggPdf.Html;
+
+/// <summary>
+/// Builds a DOM tree from HTML tokens. Implements a simplified version of the
+/// WHATWG tree construction algorithm with core insertion modes.
+/// Infallible: never throws on any input.
+/// </summary>
+internal class HtmlTreeBuilder
+{
+    private readonly HtmlDocument _document = new();
+    private readonly Stack<HtmlElement> _openElements = new();
+    private HtmlElement? _headElement;
+    private HtmlElement? _bodyElement;
+    private HtmlTokenizer? _tokenizer;
+
+    private static readonly HashSet<string> VoidElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr"
+    };
+
+    private static readonly HashSet<string> RawTextElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "script", "style", "textarea", "title"
+    };
+
+    private static readonly HashSet<string> ImplicitlyClosesParagraph = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "address", "article", "aside", "blockquote", "details", "dialog", "dd", "div", "dl",
+        "dt", "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4",
+        "h5", "h6", "header", "hgroup", "hr", "li", "main", "menu", "nav", "ol", "p", "pre",
+        "section", "summary", "table", "ul"
+    };
+
+    private static readonly HashSet<string> HeadElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "base", "basefont", "bgsound", "link", "meta", "title", "style", "script", "noscript"
+    };
+
+    public HtmlDocument Build(HtmlTokenizer tokenizer)
+    {
+        _tokenizer = tokenizer;
+        HtmlToken token;
+        while ((token = tokenizer.NextToken()).Type != HtmlTokenType.EndOfFile)
+        {
+            ProcessToken(token);
+        }
+
+        // Ensure document always has html/head/body even with empty input
+        EnsureHtmlElement();
+        EnsureHeadElement();
+        EnsureBodyElement();
+
+        return _document;
+    }
+
+    private void ProcessToken(HtmlToken token)
+    {
+        switch (token.Type)
+        {
+            case HtmlTokenType.Doctype:
+                _document.AppendChild(new HtmlDocumentType(token.DoctypeName ?? "html"));
+                break;
+
+            case HtmlTokenType.StartTag:
+                ProcessStartTag(token);
+                break;
+
+            case HtmlTokenType.EndTag:
+                ProcessEndTag(token);
+                break;
+
+            case HtmlTokenType.Character:
+                ProcessCharacter(token);
+                break;
+
+            case HtmlTokenType.Comment:
+                var parent = CurrentNode() ?? (HtmlNode)_document;
+                parent.AppendChild(new HtmlComment(token.Data ?? ""));
+                break;
+        }
+    }
+
+    private void ProcessStartTag(HtmlToken token)
+    {
+        var tagName = token.TagName!;
+
+        // html element
+        if (tagName == "html")
+        {
+            EnsureHtmlElement();
+            return;
+        }
+
+        // head element
+        if (tagName == "head")
+        {
+            EnsureHtmlElement();
+            if (_headElement == null)
+            {
+                _headElement = CreateElement(token);
+                _document.DocumentElement!.AppendChild(_headElement);
+            }
+            return;
+        }
+
+        // body element
+        if (tagName == "body")
+        {
+            EnsureHtmlElement();
+            EnsureHeadElement();
+            if (_bodyElement == null)
+            {
+                _bodyElement = CreateElement(token);
+                _document.DocumentElement!.AppendChild(_bodyElement);
+                // Set as current insertion point
+                _openElements.Clear();
+                _openElements.Push(_document.DocumentElement!);
+                _openElements.Push(_bodyElement);
+            }
+            return;
+        }
+
+        // Head content elements
+        if (_bodyElement == null && HeadElements.Contains(tagName))
+        {
+            EnsureHtmlElement();
+            EnsureHeadElement();
+
+            var elem = CreateElement(token);
+            _headElement!.AppendChild(elem);
+
+            // Raw text elements: collect text until matching end tag
+            if (RawTextElements.Contains(tagName))
+            {
+                CollectRawText(elem, tagName);
+            }
+            return;
+        }
+
+        // Everything else goes into body
+        EnsureBodyElement();
+
+        // Handle <p> implicit close
+        if (ImplicitlyClosesParagraph.Contains(tagName))
+        {
+            if (_openElements.Any(e => e.TagName == "p"))
+                CloseUpTo("p");
+        }
+
+        // Table: implicit tbody for <tr>
+        if (tagName == "tr" && _openElements.Count > 0 && _openElements.Peek().TagName == "table")
+        {
+            var tbody = new HtmlElement("tbody");
+            _openElements.Peek().AppendChild(tbody);
+            _openElements.Push(tbody);
+        }
+
+        var element = CreateElement(token);
+        var insertionPoint = CurrentNode() ?? (HtmlNode)_bodyElement!;
+        insertionPoint.AppendChild(element);
+
+        // Raw text elements in body (style in body, noscript, etc.)
+        if (RawTextElements.Contains(tagName) && tagName != "noscript")
+        {
+            CollectRawText(element, tagName);
+            return;
+        }
+
+        if (!VoidElements.Contains(tagName) && !token.SelfClosing)
+        {
+            _openElements.Push(element);
+        }
+    }
+
+    private void ProcessEndTag(HtmlToken token)
+    {
+        var tagName = token.TagName!;
+
+        if (tagName == "html" || tagName == "body" || tagName == "head")
+            return;
+
+        // Pop elements until we find matching start tag
+        var temp = new Stack<HtmlElement>();
+        bool found = false;
+
+        while (_openElements.Count > 0)
+        {
+            var top = _openElements.Peek();
+            if (top.TagName == "body" || top.TagName == "html")
+                break;
+
+            if (top.TagName == tagName)
+            {
+                _openElements.Pop();
+                found = true;
+                break;
+            }
+            temp.Push(_openElements.Pop());
+        }
+
+        if (!found)
+        {
+            // Push back
+            while (temp.Count > 0) _openElements.Push(temp.Pop());
+        }
+    }
+
+    private void ProcessCharacter(HtmlToken token)
+    {
+        if (string.IsNullOrEmpty(token.Data))
+            return;
+
+        // If body doesn't exist yet and text is whitespace, ignore
+        if (_bodyElement == null && string.IsNullOrWhiteSpace(token.Data))
+            return;
+
+        EnsureBodyElement();
+
+        var parent = CurrentNode() ?? (HtmlNode)_bodyElement!;
+
+        // Merge with previous text node
+        if (parent.ChildNodes.Count > 0 && parent.ChildNodes[parent.ChildNodes.Count - 1] is HtmlTextNode lastText)
+            lastText.Data += token.Data;
+        else
+            parent.AppendChild(new HtmlTextNode(token.Data));
+    }
+
+    /// <summary>
+    /// Consume tokens from the tokenizer until the matching end tag, collecting all text into the element.
+    /// Used for style, script, title, textarea.
+    /// </summary>
+    private void CollectRawText(HtmlElement element, string tagName)
+    {
+        if (_tokenizer == null) return;
+
+        var textBuf = new StringBuilder();
+        HtmlToken token;
+        while ((token = _tokenizer.NextToken()).Type != HtmlTokenType.EndOfFile)
+        {
+            if (token.Type == HtmlTokenType.EndTag && string.Equals(token.TagName, tagName, StringComparison.OrdinalIgnoreCase))
+                break;
+
+            if (token.Type == HtmlTokenType.Character)
+                textBuf.Append(token.Data);
+            else if (token.Type == HtmlTokenType.StartTag)
+                textBuf.Append($"<{token.TagName}>");  // raw text: tags are text
+        }
+
+        if (textBuf.Length > 0)
+            element.AppendChild(new HtmlTextNode(textBuf.ToString()));
+    }
+
+    private void EnsureHtmlElement()
+    {
+        if (_document.DocumentElement != null) return;
+        var html = new HtmlElement("html");
+        _document.AppendChild(html);
+        _openElements.Push(html);
+    }
+
+    private void EnsureHeadElement()
+    {
+        if (_headElement != null) return;
+        EnsureHtmlElement();
+        _headElement = new HtmlElement("head");
+        _document.DocumentElement!.AppendChild(_headElement);
+    }
+
+    private void EnsureBodyElement()
+    {
+        if (_bodyElement != null) return;
+        EnsureHtmlElement();
+        EnsureHeadElement();
+        _bodyElement = new HtmlElement("body");
+        _document.DocumentElement!.AppendChild(_bodyElement);
+        _openElements.Clear();
+        _openElements.Push(_document.DocumentElement!);
+        _openElements.Push(_bodyElement);
+    }
+
+    private void CloseUpTo(string tagName)
+    {
+        while (_openElements.Count > 0)
+        {
+            var top = _openElements.Peek();
+            if (top.TagName == "body" || top.TagName == "html") return;
+            if (top.TagName == tagName) { _openElements.Pop(); return; }
+            _openElements.Pop();
+        }
+    }
+
+    private HtmlElement? CurrentNode() => _openElements.Count > 0 ? _openElements.Peek() : null;
+
+    private static HtmlElement CreateElement(HtmlToken token)
+    {
+        var elem = new HtmlElement(token.TagName!);
+        foreach (var attr in token.Attributes)
+            elem.SetAttribute(attr.Name, attr.Value);
+        return elem;
+    }
+}

--- a/tests/EggPdf.Tests.Unit/Html/HtmlParserTests.cs
+++ b/tests/EggPdf.Tests.Unit/Html/HtmlParserTests.cs
@@ -1,0 +1,237 @@
+using EggPdf.Html;
+using EggPdf.Html.Dom;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Html;
+
+public class HtmlParserTests
+{
+    private static HtmlDocument Parse(string html) => HtmlParser.Parse(html);
+
+    [Fact]
+    public void EmptyString_ProducesValidDocument()
+    {
+        var doc = Parse("");
+
+        doc.Should().NotBeNull();
+        doc.DocumentElement.Should().NotBeNull();
+        doc.DocumentElement!.TagName.Should().Be("html");
+        doc.Head.Should().NotBeNull();
+        doc.Body.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SimpleHtml_CreatesCorrectStructure()
+    {
+        var doc = Parse("<html><head></head><body><p>Hello</p></body></html>");
+
+        doc.DocumentElement!.TagName.Should().Be("html");
+        doc.Head!.TagName.Should().Be("head");
+        doc.Body!.TagName.Should().Be("body");
+        doc.Body.ChildNodes.Should().HaveCount(1);
+
+        var p = doc.Body.ChildNodes[0] as HtmlElement;
+        p.Should().NotBeNull();
+        p!.TagName.Should().Be("p");
+        p.ChildNodes.Should().HaveCount(1);
+
+        var text = p.ChildNodes[0] as HtmlTextNode;
+        text.Should().NotBeNull();
+        text!.Data.Should().Be("Hello");
+    }
+
+    [Fact]
+    public void MissingHtmlHeadBody_ImplicitlyCreated()
+    {
+        var doc = Parse("<p>Hello</p>");
+
+        doc.DocumentElement.Should().NotBeNull();
+        doc.Head.Should().NotBeNull();
+        doc.Body.Should().NotBeNull();
+
+        // <p> should be inside <body>
+        doc.Body!.ChildNodes.OfType<HtmlElement>().Should().Contain(e => e.TagName == "p");
+    }
+
+    [Fact]
+    public void NestedDivs_CorrectHierarchy()
+    {
+        var doc = Parse("<div><div><span>inner</span></div></div>");
+
+        var body = doc.Body!;
+        var outerDiv = body.ChildNodes[0] as HtmlElement;
+        outerDiv!.TagName.Should().Be("div");
+
+        var innerDiv = outerDiv.ChildNodes[0] as HtmlElement;
+        innerDiv!.TagName.Should().Be("div");
+
+        var span = innerDiv.ChildNodes[0] as HtmlElement;
+        span!.TagName.Should().Be("span");
+
+        var text = span.ChildNodes[0] as HtmlTextNode;
+        text!.Data.Should().Be("inner");
+    }
+
+    [Fact]
+    public void VoidElements_NoChildren()
+    {
+        var doc = Parse("<br><hr><img src='test.png'>");
+
+        var body = doc.Body!;
+        body.ChildNodes.Should().HaveCount(3);
+
+        foreach (var child in body.ChildNodes)
+        {
+            var elem = child as HtmlElement;
+            elem.Should().NotBeNull();
+            elem!.ChildNodes.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public void ImgAttributes_Preserved()
+    {
+        var doc = Parse("<img src='logo.png' alt='Logo' width='100'>");
+
+        var body = doc.Body!;
+        var img = body.ChildNodes[0] as HtmlElement;
+        img!.TagName.Should().Be("img");
+        img.GetAttribute("src").Should().Be("logo.png");
+        img.GetAttribute("alt").Should().Be("Logo");
+        img.GetAttribute("width").Should().Be("100");
+    }
+
+    [Fact]
+    public void ParagraphsImplicitlyClose()
+    {
+        // <p> is implicitly closed by another <p>
+        var doc = Parse("<p>First<p>Second");
+
+        var body = doc.Body!;
+        var paragraphs = body.ChildNodes.OfType<HtmlElement>().Where(e => e.TagName == "p").ToList();
+        paragraphs.Should().HaveCount(2);
+        (paragraphs[0].ChildNodes[0] as HtmlTextNode)!.Data.Should().Be("First");
+        (paragraphs[1].ChildNodes[0] as HtmlTextNode)!.Data.Should().Be("Second");
+    }
+
+    [Fact]
+    public void Table_BasicStructure()
+    {
+        var doc = Parse("<table><tr><td>Cell</td></tr></table>");
+
+        var body = doc.Body!;
+        var table = body.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "table");
+        table.Should().NotBeNull();
+
+        // Should have tbody (implicitly created) containing tr
+        var tbody = table.ChildNodes.OfType<HtmlElement>().FirstOrDefault(e => e.TagName == "tbody");
+        tbody.Should().NotBeNull();
+
+        var tr = tbody!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "tr");
+        var td = tr.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "td");
+        (td.ChildNodes[0] as HtmlTextNode)!.Data.Should().Be("Cell");
+    }
+
+    [Fact]
+    public void StyleTag_ContainsRawText()
+    {
+        var doc = Parse("<style>body { color: red; }</style>");
+
+        var head = doc.Head!;
+        var style = head.ChildNodes.OfType<HtmlElement>().FirstOrDefault(e => e.TagName == "style");
+        style.Should().NotBeNull();
+
+        var text = style!.ChildNodes[0] as HtmlTextNode;
+        text!.Data.Should().Be("body { color: red; }");
+    }
+
+    [Fact]
+    public void TitleTag_ContainsText()
+    {
+        var doc = Parse("<title>My Page</title>");
+
+        var head = doc.Head!;
+        var title = head.ChildNodes.OfType<HtmlElement>().FirstOrDefault(e => e.TagName == "title");
+        title.Should().NotBeNull();
+
+        var text = title!.ChildNodes[0] as HtmlTextNode;
+        text!.Data.Should().Be("My Page");
+    }
+
+    [Fact]
+    public void Doctype_Recognized()
+    {
+        var doc = Parse("<!DOCTYPE html><html><body></body></html>");
+
+        doc.DocumentElement.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Comment_PreservedInDom()
+    {
+        var doc = Parse("<body><!-- hello --><p>text</p></body>");
+
+        var body = doc.Body!;
+        body.ChildNodes.OfType<HtmlComment>().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void HiddenAttribute_Preserved()
+    {
+        var doc = Parse("<div hidden>secret</div>");
+
+        var div = doc.Body!.ChildNodes.OfType<HtmlElement>().First();
+        div.HasAttribute("hidden").Should().BeTrue();
+    }
+
+    [Fact]
+    public void NoscriptContent_Present()
+    {
+        // We don't execute JS, so noscript content should be in the DOM
+        var doc = Parse("<body><noscript>JS disabled</noscript></body>");
+
+        var body = doc.Body!;
+        var noscript = body.ChildNodes.OfType<HtmlElement>().FirstOrDefault(e => e.TagName == "noscript");
+        noscript.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void IdAndClassAccessors_Work()
+    {
+        var doc = Parse("<div id='main' class='container flex'></div>");
+
+        var div = doc.Body!.ChildNodes.OfType<HtmlElement>().First();
+        div.Id.Should().Be("main");
+        div.ClassList.Should().BeEquivalentTo(new[] { "container", "flex" });
+    }
+
+    [Fact]
+    public void NeverThrows_OnMalformedInput()
+    {
+        // The parser must be infallible
+        var malformedInputs = new[]
+        {
+            "<",
+            "<<>>",
+            "<//>",
+            "<div><span></div></span>",
+            "<p><p><p>",
+            "<<<>>><<<",
+            "&;&#;&#x;",
+            "<div attr='unclosed",
+            "<div attr=\"unclosed",
+            "",
+            "   ",
+            "<script><div></div></script>",
+            "<!-broken comment-->",
+            "<!DOCTYPE>",
+        };
+
+        foreach (var input in malformedInputs)
+        {
+            var act = () => Parse(input);
+            act.Should().NotThrow($"input '{input}' should not cause an exception");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- DOM: HtmlDocument, HtmlElement, HtmlTextNode, HtmlComment, HtmlDocumentType
- Tree builder: implicit html/head/body, void elements, paragraph closing, raw text, table tbody
- HtmlParser.Parse() facade wires tokenizer + tree builder
- Infallible: 14 malformed inputs tested, none throw

## Test Evidence
- 16 new parser tests, 87 total passing
- Covers: structure, nesting, void elements, attributes, implicit closing, raw text, comments, doctype, malformed input

## Checklist
- [x] Tests written FIRST
- [x] All 87 tests pass
- [x] No external dependencies
- [x] Multi-target compatible

Closes #4

Generated with [Claude Code](https://claude.com/claude-code)