### PR TITLE
feat: basic CSS parser (inline styles + UA defaults)

### DIFF
--- a/src/EggPdf.Css/BasicStyleResolver.cs
+++ b/src/EggPdf.Css/BasicStyleResolver.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using EggPdf.Html.Dom;
+
+namespace EggPdf.Css;
+
+/// <summary>
+/// Phase 1 style resolver: applies UA defaults + inline styles.
+/// No external stylesheets, no specificity, no cascade. Just inline + defaults.
+/// </summary>
+public class BasicStyleResolver
+{
+    // Inherited properties (child inherits from parent if not explicitly set)
+    private static readonly HashSet<string> InheritedProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "color", "font-family", "font-size", "font-weight", "font-style",
+        "line-height", "text-align", "text-indent", "text-transform",
+        "letter-spacing", "word-spacing", "white-space", "direction",
+        "visibility", "list-style-type", "list-style-position",
+        "border-collapse", "border-spacing", "caption-side", "empty-cells"
+    };
+
+    // UA defaults per element
+    private static readonly Dictionary<string, Dictionary<string, string>> UaDefaults = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["html"] = new() { ["display"] = "block" },
+        ["body"] = new() { ["display"] = "block", ["margin-top"] = "8px", ["margin-right"] = "8px", ["margin-bottom"] = "8px", ["margin-left"] = "8px" },
+        ["div"] = new() { ["display"] = "block" },
+        ["section"] = new() { ["display"] = "block" },
+        ["article"] = new() { ["display"] = "block" },
+        ["aside"] = new() { ["display"] = "block" },
+        ["header"] = new() { ["display"] = "block" },
+        ["footer"] = new() { ["display"] = "block" },
+        ["nav"] = new() { ["display"] = "block" },
+        ["main"] = new() { ["display"] = "block" },
+        ["p"] = new() { ["display"] = "block", ["margin-top"] = "1em", ["margin-bottom"] = "1em" },
+        ["h1"] = new() { ["display"] = "block", ["font-size"] = "2em", ["font-weight"] = "bold", ["margin-top"] = "0.67em", ["margin-bottom"] = "0.67em" },
+        ["h2"] = new() { ["display"] = "block", ["font-size"] = "1.5em", ["font-weight"] = "bold", ["margin-top"] = "0.83em", ["margin-bottom"] = "0.83em" },
+        ["h3"] = new() { ["display"] = "block", ["font-size"] = "1.17em", ["font-weight"] = "bold", ["margin-top"] = "1em", ["margin-bottom"] = "1em" },
+        ["h4"] = new() { ["display"] = "block", ["font-weight"] = "bold", ["margin-top"] = "1.33em", ["margin-bottom"] = "1.33em" },
+        ["h5"] = new() { ["display"] = "block", ["font-size"] = "0.83em", ["font-weight"] = "bold", ["margin-top"] = "1.67em", ["margin-bottom"] = "1.67em" },
+        ["h6"] = new() { ["display"] = "block", ["font-size"] = "0.67em", ["font-weight"] = "bold", ["margin-top"] = "2.33em", ["margin-bottom"] = "2.33em" },
+        ["ul"] = new() { ["display"] = "block", ["margin-top"] = "1em", ["margin-bottom"] = "1em", ["padding-left"] = "40px", ["list-style-type"] = "disc" },
+        ["ol"] = new() { ["display"] = "block", ["margin-top"] = "1em", ["margin-bottom"] = "1em", ["padding-left"] = "40px", ["list-style-type"] = "decimal" },
+        ["li"] = new() { ["display"] = "list-item" },
+        ["blockquote"] = new() { ["display"] = "block", ["margin-top"] = "1em", ["margin-bottom"] = "1em", ["margin-left"] = "40px", ["margin-right"] = "40px" },
+        ["pre"] = new() { ["display"] = "block", ["font-family"] = "monospace", ["white-space"] = "pre", ["margin-top"] = "1em", ["margin-bottom"] = "1em" },
+        ["hr"] = new() { ["display"] = "block", ["margin-top"] = "0.5em", ["margin-bottom"] = "0.5em", ["border-top-style"] = "inset", ["border-top-width"] = "1px" },
+        ["a"] = new() { ["color"] = "blue", ["text-decoration"] = "underline" },
+        ["strong"] = new() { ["font-weight"] = "bold" },
+        ["b"] = new() { ["font-weight"] = "bold" },
+        ["em"] = new() { ["font-style"] = "italic" },
+        ["i"] = new() { ["font-style"] = "italic" },
+        ["u"] = new() { ["text-decoration"] = "underline" },
+        ["s"] = new() { ["text-decoration"] = "line-through" },
+        ["del"] = new() { ["text-decoration"] = "line-through" },
+        ["small"] = new() { ["font-size"] = "smaller" },
+        ["code"] = new() { ["font-family"] = "monospace" },
+        ["kbd"] = new() { ["font-family"] = "monospace" },
+        ["samp"] = new() { ["font-family"] = "monospace" },
+        ["var"] = new() { ["font-style"] = "italic" },
+        ["mark"] = new() { ["background-color"] = "yellow", ["color"] = "black" },
+        ["table"] = new() { ["display"] = "table", ["border-collapse"] = "separate", ["border-spacing"] = "2px" },
+        ["thead"] = new() { ["display"] = "table-header-group" },
+        ["tbody"] = new() { ["display"] = "table-row-group" },
+        ["tfoot"] = new() { ["display"] = "table-footer-group" },
+        ["tr"] = new() { ["display"] = "table-row" },
+        ["td"] = new() { ["display"] = "table-cell", ["padding-top"] = "1px", ["padding-right"] = "1px", ["padding-bottom"] = "1px", ["padding-left"] = "1px" },
+        ["th"] = new() { ["display"] = "table-cell", ["font-weight"] = "bold", ["text-align"] = "center", ["padding-top"] = "1px", ["padding-right"] = "1px", ["padding-bottom"] = "1px", ["padding-left"] = "1px" },
+        ["caption"] = new() { ["display"] = "table-caption", ["text-align"] = "center" },
+        ["img"] = new() { ["display"] = "inline" },
+        ["br"] = new() { ["display"] = "inline" },
+        ["span"] = new() { ["display"] = "inline" },
+        ["sub"] = new() { ["vertical-align"] = "sub", ["font-size"] = "smaller" },
+        ["sup"] = new() { ["vertical-align"] = "super", ["font-size"] = "smaller" },
+        ["fieldset"] = new() { ["display"] = "block", ["border-top-width"] = "2px", ["border-right-width"] = "2px", ["border-bottom-width"] = "2px", ["border-left-width"] = "2px", ["border-top-style"] = "groove" },
+        ["address"] = new() { ["display"] = "block", ["font-style"] = "italic" },
+        ["center"] = new() { ["display"] = "block", ["text-align"] = "center" },
+        ["figure"] = new() { ["display"] = "block", ["margin-top"] = "1em", ["margin-bottom"] = "1em", ["margin-left"] = "40px", ["margin-right"] = "40px" },
+        ["figcaption"] = new() { ["display"] = "block" },
+        ["details"] = new() { ["display"] = "block" },
+        ["summary"] = new() { ["display"] = "list-item" },
+    };
+
+    /// <summary>
+    /// Resolve the computed style for an element.
+    /// </summary>
+    public ComputedStyle Resolve(HtmlElement element, ComputedStyle? parentStyle)
+    {
+        var style = new ComputedStyle();
+
+        // 1. Apply UA defaults
+        if (UaDefaults.TryGetValue(element.TagName, out var defaults))
+        {
+            foreach (var kv in defaults)
+                style.Set(kv.Key, kv.Value);
+        }
+
+        // Default display for unknown elements
+        if (!style.Has("display"))
+            style.Set("display", "inline");
+
+        // 2. Inherit from parent
+        if (parentStyle != null)
+        {
+            foreach (var prop in InheritedProperties)
+            {
+                if (!style.Has(prop))
+                {
+                    var parentVal = parentStyle.Get(prop);
+                    if (parentVal != null)
+                        style.Set(prop, parentVal);
+                }
+            }
+        }
+
+        // 3. Apply inline styles (highest priority)
+        var inlineCss = element.GetAttribute("style");
+        if (!string.IsNullOrEmpty(inlineCss))
+        {
+            var declarations = CssInlineParser.Parse(inlineCss);
+            foreach (var decl in declarations)
+                style.Set(decl.Property, decl.Value);
+        }
+
+        // 4. Handle hidden attribute
+        if (element.HasAttribute("hidden"))
+            style.Set("display", "none");
+
+        return style;
+    }
+}

--- a/src/EggPdf.Css/ComputedStyle.cs
+++ b/src/EggPdf.Css/ComputedStyle.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+namespace EggPdf.Css;
+
+/// <summary>
+/// Stores resolved CSS property values for an element.
+/// For Phase 1, this is a simple string dictionary. Later phases will use typed values.
+/// </summary>
+public class ComputedStyle
+{
+    private readonly Dictionary<string, string> _properties = new(StringComparer.OrdinalIgnoreCase);
+
+    public string? Get(string property)
+        => _properties.TryGetValue(property, out var val) ? val : null;
+
+    public void Set(string property, string value)
+        => _properties[property] = value;
+
+    public bool Has(string property) => _properties.ContainsKey(property);
+
+    public IEnumerable<KeyValuePair<string, string>> All => _properties;
+
+    // Common property shortcuts
+    public string Display => Get("display") ?? "inline";
+    public string? Color => Get("color");
+    public string? BackgroundColor => Get("background-color");
+    public string? FontSize => Get("font-size");
+    public string? FontWeight => Get("font-weight");
+    public string? FontFamily => Get("font-family");
+    public string? TextAlign => Get("text-align");
+    public string? Width => Get("width");
+    public string? Height => Get("height");
+    public string? MarginTop => Get("margin-top");
+    public string? MarginRight => Get("margin-right");
+    public string? MarginBottom => Get("margin-bottom");
+    public string? MarginLeft => Get("margin-left");
+    public string? PaddingTop => Get("padding-top");
+    public string? PaddingRight => Get("padding-right");
+    public string? PaddingBottom => Get("padding-bottom");
+    public string? PaddingLeft => Get("padding-left");
+}

--- a/src/EggPdf.Css/CssDeclaration.cs
+++ b/src/EggPdf.Css/CssDeclaration.cs
@@ -1,0 +1,18 @@
+namespace EggPdf.Css;
+
+/// <summary>
+/// A single CSS property declaration (e.g., "color: red !important").
+/// </summary>
+public class CssDeclaration
+{
+    public string Property { get; }
+    public string Value { get; }
+    public bool Important { get; }
+
+    public CssDeclaration(string property, string value, bool important = false)
+    {
+        Property = property;
+        Value = value;
+        Important = important;
+    }
+}

--- a/src/EggPdf.Css/CssInlineParser.cs
+++ b/src/EggPdf.Css/CssInlineParser.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+
+namespace EggPdf.Css;
+
+/// <summary>
+/// Parses inline CSS from style="" attributes into a list of declarations.
+/// Infallible: never throws. Invalid syntax is skipped.
+/// </summary>
+public static class CssInlineParser
+{
+    public static List<CssDeclaration> Parse(string? css)
+    {
+        var declarations = new List<CssDeclaration>();
+
+        if (string.IsNullOrWhiteSpace(css))
+            return declarations;
+
+        // Split by semicolons (simple approach for inline styles)
+        var parts = css.Split(';');
+
+        foreach (var part in parts)
+        {
+            var trimmed = part.Trim();
+            if (string.IsNullOrEmpty(trimmed))
+                continue;
+
+            // Find the colon separating property from value
+            int colonIndex = trimmed.IndexOf(':');
+            if (colonIndex <= 0 || colonIndex >= trimmed.Length - 1)
+                continue;
+
+            var property = trimmed.Substring(0, colonIndex).Trim().ToLowerInvariant();
+            var value = trimmed.Substring(colonIndex + 1).Trim();
+
+            // Skip invalid property names
+            if (string.IsNullOrEmpty(property) || property.Contains(" "))
+                continue;
+
+            // Check for !important
+            bool important = false;
+            if (value.EndsWith("!important", StringComparison.OrdinalIgnoreCase) ||
+                value.EndsWith("! important", StringComparison.OrdinalIgnoreCase))
+            {
+                important = true;
+                int bangIndex = value.LastIndexOf('!');
+                value = value.Substring(0, bangIndex).Trim();
+            }
+
+            if (string.IsNullOrEmpty(value))
+                continue;
+
+            declarations.Add(new CssDeclaration(property, value, important));
+        }
+
+        return declarations;
+    }
+}

--- a/src/EggPdf.Css/Placeholder.cs
+++ b/src/EggPdf.Css/Placeholder.cs
@@ -1,1 +1,0 @@
-namespace EggPdf.Css;

--- a/tests/EggPdf.Tests.Unit/Css/BasicStyleResolverTests.cs
+++ b/tests/EggPdf.Tests.Unit/Css/BasicStyleResolverTests.cs
@@ -1,0 +1,166 @@
+using EggPdf.Css;
+using EggPdf.Html.Dom;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Css;
+
+public class BasicStyleResolverTests
+{
+    private readonly BasicStyleResolver _resolver = new();
+
+    [Fact]
+    public void Div_DisplayBlock()
+    {
+        var elem = new HtmlElement("div");
+        var style = _resolver.Resolve(elem, null);
+
+        style.Display.Should().Be("block");
+    }
+
+    [Fact]
+    public void Span_DisplayInline()
+    {
+        var elem = new HtmlElement("span");
+        var style = _resolver.Resolve(elem, null);
+
+        style.Display.Should().Be("inline");
+    }
+
+    [Fact]
+    public void H1_HasCorrectDefaults()
+    {
+        var elem = new HtmlElement("h1");
+        var style = _resolver.Resolve(elem, null);
+
+        style.Display.Should().Be("block");
+        style.FontSize.Should().Be("2em");
+        style.FontWeight.Should().Be("bold");
+    }
+
+    [Fact]
+    public void P_HasMargins()
+    {
+        var elem = new HtmlElement("p");
+        var style = _resolver.Resolve(elem, null);
+
+        style.MarginTop.Should().Be("1em");
+        style.MarginBottom.Should().Be("1em");
+    }
+
+    [Fact]
+    public void A_HasColorAndUnderline()
+    {
+        var elem = new HtmlElement("a");
+        var style = _resolver.Resolve(elem, null);
+
+        style.Color.Should().Be("blue");
+        style.Get("text-decoration").Should().Be("underline");
+    }
+
+    [Fact]
+    public void InlineStyle_OverridesDefaults()
+    {
+        var elem = new HtmlElement("div");
+        elem.SetAttribute("style", "color: red; display: flex");
+        var style = _resolver.Resolve(elem, null);
+
+        style.Color.Should().Be("red");
+        style.Display.Should().Be("flex");
+    }
+
+    [Fact]
+    public void InheritedProperty_InheritsFromParent()
+    {
+        var parentStyle = new ComputedStyle();
+        parentStyle.Set("color", "blue");
+        parentStyle.Set("font-family", "Arial");
+
+        var child = new HtmlElement("span");
+        var style = _resolver.Resolve(child, parentStyle);
+
+        style.Color.Should().Be("blue");
+        style.FontFamily.Should().Be("Arial");
+    }
+
+    [Fact]
+    public void NonInheritedProperty_DoesNotInherit()
+    {
+        var parentStyle = new ComputedStyle();
+        parentStyle.Set("margin-top", "20px");
+        parentStyle.Set("padding-left", "10px");
+
+        var child = new HtmlElement("span");
+        var style = _resolver.Resolve(child, parentStyle);
+
+        style.MarginTop.Should().BeNull();
+        style.PaddingLeft.Should().BeNull();
+    }
+
+    [Fact]
+    public void HiddenAttribute_DisplayNone()
+    {
+        var elem = new HtmlElement("div");
+        elem.SetAttribute("hidden", "");
+        var style = _resolver.Resolve(elem, null);
+
+        style.Display.Should().Be("none");
+    }
+
+    [Fact]
+    public void UnknownElement_DisplayInline()
+    {
+        var elem = new HtmlElement("custom-element");
+        var style = _resolver.Resolve(elem, null);
+
+        style.Display.Should().Be("inline");
+    }
+
+    [Fact]
+    public void Table_DisplayTable()
+    {
+        var elem = new HtmlElement("table");
+        var style = _resolver.Resolve(elem, null);
+
+        style.Display.Should().Be("table");
+    }
+
+    [Fact]
+    public void Td_DisplayTableCell()
+    {
+        var elem = new HtmlElement("td");
+        var style = _resolver.Resolve(elem, null);
+
+        style.Display.Should().Be("table-cell");
+    }
+
+    [Fact]
+    public void Code_MonospaceFont()
+    {
+        var elem = new HtmlElement("code");
+        var style = _resolver.Resolve(elem, null);
+
+        style.FontFamily.Should().Be("monospace");
+    }
+
+    [Fact]
+    public void Strong_Bold()
+    {
+        var elem = new HtmlElement("strong");
+        var style = _resolver.Resolve(elem, null);
+
+        style.FontWeight.Should().Be("bold");
+    }
+
+    [Fact]
+    public void Body_Has8pxMargin()
+    {
+        var elem = new HtmlElement("body");
+        var style = _resolver.Resolve(elem, null);
+
+        style.MarginTop.Should().Be("8px");
+        style.MarginRight.Should().Be("8px");
+        style.MarginBottom.Should().Be("8px");
+        style.MarginLeft.Should().Be("8px");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/Css/CssInlineParserTests.cs
+++ b/tests/EggPdf.Tests.Unit/Css/CssInlineParserTests.cs
@@ -1,0 +1,106 @@
+using System.Linq;
+using EggPdf.Css;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Css;
+
+public class CssInlineParserTests
+{
+    [Fact]
+    public void Parse_SingleProperty_ReturnsDeclaration()
+    {
+        var decls = CssInlineParser.Parse("color: red");
+
+        decls.Should().HaveCount(1);
+        decls[0].Property.Should().Be("color");
+        decls[0].Value.Should().Be("red");
+    }
+
+    [Fact]
+    public void Parse_MultipleProperties_ReturnsAll()
+    {
+        var decls = CssInlineParser.Parse("color: red; font-size: 16px; margin: 10px");
+
+        decls.Should().HaveCount(3);
+        decls[0].Property.Should().Be("color");
+        decls[0].Value.Should().Be("red");
+        decls[1].Property.Should().Be("font-size");
+        decls[1].Value.Should().Be("16px");
+        decls[2].Property.Should().Be("margin");
+        decls[2].Value.Should().Be("10px");
+    }
+
+    [Fact]
+    public void Parse_WithWhitespace_TrimsValues()
+    {
+        var decls = CssInlineParser.Parse("  color :  blue  ;  font-weight :  bold  ");
+
+        decls.Should().HaveCount(2);
+        decls[0].Property.Should().Be("color");
+        decls[0].Value.Should().Be("blue");
+        decls[1].Property.Should().Be("font-weight");
+        decls[1].Value.Should().Be("bold");
+    }
+
+    [Fact]
+    public void Parse_Important_Detected()
+    {
+        var decls = CssInlineParser.Parse("color: red !important");
+
+        decls.Should().HaveCount(1);
+        decls[0].Property.Should().Be("color");
+        decls[0].Value.Should().Be("red");
+        decls[0].Important.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_EmptyString_ReturnsEmpty()
+    {
+        var decls = CssInlineParser.Parse("");
+        decls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_NullString_ReturnsEmpty()
+    {
+        var decls = CssInlineParser.Parse(null!);
+        decls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_InvalidSyntax_SkipsInvalid()
+    {
+        var decls = CssInlineParser.Parse("not-valid; color: red; :::; font-size: 12px");
+
+        // Should still get the valid ones
+        decls.Should().Contain(d => d.Property == "color");
+        decls.Should().Contain(d => d.Property == "font-size");
+    }
+
+    [Fact]
+    public void Parse_ValueWithSpaces_PreservesSpaces()
+    {
+        var decls = CssInlineParser.Parse("font-family: Arial, Helvetica, sans-serif");
+
+        decls[0].Property.Should().Be("font-family");
+        decls[0].Value.Should().Be("Arial, Helvetica, sans-serif");
+    }
+
+    [Fact]
+    public void Parse_ValueWithUrl_PreservesUrl()
+    {
+        var decls = CssInlineParser.Parse("background-image: url('image.png')");
+
+        decls[0].Property.Should().Be("background-image");
+        decls[0].Value.Should().Be("url('image.png')");
+    }
+
+    [Fact]
+    public void Parse_TrailingSemicolon_NoExtraDeclaration()
+    {
+        var decls = CssInlineParser.Parse("color: red;");
+
+        decls.Should().HaveCount(1);
+    }
+}


### PR DESCRIPTION
## Summary
- CssInlineParser: parse style="" into declarations (handles !important, whitespace, URLs)
- BasicStyleResolver: UA defaults for 50+ elements + inherited properties + inline override
- ComputedStyle: property store with common shortcuts
- Infallible: invalid CSS silently skipped

## Test Evidence
- 25 new tests, 112 total passing

Closes #5

Generated with [Claude Code](https://claude.com/claude-code)