### PR TITLE
feat: CSS cascade + @media print (Phase 2 complete)

### DIFF
--- a/src/EggPdf.Css/Cascade/CascadeResolver.cs
+++ b/src/EggPdf.Css/Cascade/CascadeResolver.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EggPdf.Css.Parser;
+using EggPdf.Css.Selectors;
+using EggPdf.Html.Dom;
+
+namespace EggPdf.Css.Cascade;
+
+/// <summary>
+/// Resolves the computed style for an element by applying the CSS cascade:
+/// UA defaults -> author stylesheets (by specificity) -> inline styles.
+/// Handles @media filtering, !important, inheritance.
+/// </summary>
+public class CascadeResolver
+{
+    private readonly List<CssStyleRule> _authorRules = new();
+    private readonly BasicStyleResolver _uaResolver = new();
+    private readonly string _mediaType;
+
+    public CascadeResolver(IEnumerable<CssStyleSheet> stylesheets, string mediaType = "print")
+    {
+        _mediaType = mediaType;
+
+        foreach (var sheet in stylesheets)
+        {
+            // Direct rules
+            _authorRules.AddRange(sheet.Rules);
+
+            // @media rules - include if media matches
+            foreach (var mediaRule in sheet.MediaRules)
+            {
+                if (MediaMatches(mediaRule.MediaQuery))
+                    _authorRules.AddRange(mediaRule.Rules);
+            }
+        }
+    }
+
+    /// <summary>Resolve computed style for an element.</summary>
+    public ComputedStyle Resolve(HtmlElement element, ComputedStyle? parentStyle)
+    {
+        // 1. Start with UA defaults + inheritance
+        var style = _uaResolver.Resolve(element, parentStyle);
+
+        // 2. Collect matching author rules with specificity
+        var matches = new List<(CssDeclaration decl, int specificity, int order)>();
+        int ruleOrder = 0;
+
+        foreach (var rule in _authorRules)
+        {
+            if (SelectorMatcher.Matches(rule.SelectorText, element))
+            {
+                var spec = SelectorMatcher.CalculateSpecificity(rule.SelectorText);
+                int specScore = spec.A * 10000 + spec.B * 100 + spec.C;
+
+                foreach (var decl in rule.Declarations)
+                {
+                    matches.Add((decl, specScore, ruleOrder));
+                }
+            }
+            ruleOrder++;
+        }
+
+        // 3. Sort: !important first, then by specificity, then by source order
+        var sorted = matches
+            .OrderBy(m => m.decl.Important ? 0 : 1)  // !important first
+            .ThenBy(m => m.specificity)
+            .ThenBy(m => m.order)
+            .ToList();
+
+        // 4. Apply in order (later wins for same property at same importance level)
+        // Group by property, last one wins (unless !important overrides)
+        var propertyWinners = new Dictionary<string, (string value, bool important, int specificity, int order)>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (decl, spec, order) in sorted)
+        {
+            if (propertyWinners.TryGetValue(decl.Property, out var existing))
+            {
+                // !important always wins over non-important
+                if (decl.Important && !existing.important)
+                {
+                    propertyWinners[decl.Property] = (decl.Value, decl.Important, spec, order);
+                }
+                else if (decl.Important == existing.important)
+                {
+                    // Same importance: higher specificity wins, or later source order
+                    if (spec > existing.specificity || (spec == existing.specificity && order >= existing.order))
+                    {
+                        propertyWinners[decl.Property] = (decl.Value, decl.Important, spec, order);
+                    }
+                }
+                // non-important cannot override !important
+            }
+            else
+            {
+                propertyWinners[decl.Property] = (decl.Value, decl.Important, spec, order);
+            }
+        }
+
+        // Apply winners to style
+        foreach (var kv in propertyWinners)
+            style.Set(kv.Key, kv.Value.value);
+
+        // 5. Apply inline styles (highest priority, except for !important in stylesheets)
+        var inlineCss = element.GetAttribute("style");
+        if (!string.IsNullOrEmpty(inlineCss))
+        {
+            var inlineDecls = CssInlineParser.Parse(inlineCss);
+            foreach (var decl in inlineDecls)
+            {
+                // Inline styles override author styles unless author has !important
+                if (propertyWinners.TryGetValue(decl.Property, out var existing) && existing.important && !decl.Important)
+                    continue; // author !important wins over inline non-important
+
+                style.Set(decl.Property, decl.Value);
+            }
+        }
+
+        // 6. Handle hidden attribute
+        if (element.HasAttribute("hidden"))
+            style.Set("display", "none");
+
+        return style;
+    }
+
+    private bool MediaMatches(string mediaQuery)
+    {
+        var query = mediaQuery.Trim().ToLowerInvariant();
+
+        if (string.IsNullOrEmpty(query) || query == "all")
+            return true;
+
+        // Simple media type matching
+        if (query == _mediaType)
+            return true;
+
+        if (query == "screen" && _mediaType == "print")
+            return false;
+
+        if (query == "print" && _mediaType == "screen")
+            return false;
+
+        // "not print" etc.
+        if (query.StartsWith("not "))
+        {
+            var negated = query.Substring(4).Trim();
+            return negated != _mediaType;
+        }
+
+        // Unknown media query: include by default
+        return true;
+    }
+}

--- a/tests/EggPdf.Tests.Unit/Css/CascadeResolverTests.cs
+++ b/tests/EggPdf.Tests.Unit/Css/CascadeResolverTests.cs
@@ -1,0 +1,174 @@
+using EggPdf.Css;
+using EggPdf.Css.Cascade;
+using EggPdf.Css.Parser;
+using EggPdf.Html;
+using EggPdf.Html.Dom;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Css;
+
+public class CascadeResolverTests
+{
+    [Fact]
+    public void StylesheetRule_AppliedToMatchingElement()
+    {
+        var doc = HtmlParser.Parse("<p>Hello</p>");
+        var sheet = CssStyleSheetParser.Parse("p { color: red; }");
+        var resolver = new CascadeResolver(new[] { sheet });
+
+        var p = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "p");
+        var style = resolver.Resolve(p, null);
+
+        style.Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void InlineStyle_OverridesStylesheet()
+    {
+        var doc = HtmlParser.Parse("<p style='color: blue'>Hello</p>");
+        var sheet = CssStyleSheetParser.Parse("p { color: red; }");
+        var resolver = new CascadeResolver(new[] { sheet });
+
+        var p = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "p");
+        var style = resolver.Resolve(p, null);
+
+        style.Color.Should().Be("blue");
+    }
+
+    [Fact]
+    public void HigherSpecificity_Wins()
+    {
+        var doc = HtmlParser.Parse("<p class='highlight'>Hello</p>");
+        var sheet = CssStyleSheetParser.Parse("p { color: red; } .highlight { color: green; }");
+        var resolver = new CascadeResolver(new[] { sheet });
+
+        var p = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "p");
+        var style = resolver.Resolve(p, null);
+
+        // .highlight (0,1,0) beats p (0,0,1)
+        style.Color.Should().Be("green");
+    }
+
+    [Fact]
+    public void Important_BeatsHigherSpecificity()
+    {
+        var doc = HtmlParser.Parse("<p class='highlight'>Hello</p>");
+        var sheet = CssStyleSheetParser.Parse("p { color: red !important; } .highlight { color: green; }");
+        var resolver = new CascadeResolver(new[] { sheet });
+
+        var p = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "p");
+        var style = resolver.Resolve(p, null);
+
+        style.Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void LaterRule_WinsAtSameSpecificity()
+    {
+        var doc = HtmlParser.Parse("<p>Hello</p>");
+        var sheet = CssStyleSheetParser.Parse("p { color: red; } p { color: blue; }");
+        var resolver = new CascadeResolver(new[] { sheet });
+
+        var p = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "p");
+        var style = resolver.Resolve(p, null);
+
+        style.Color.Should().Be("blue");
+    }
+
+    [Fact]
+    public void UaDefaults_StillApplied()
+    {
+        var doc = HtmlParser.Parse("<h1>Title</h1>");
+        var sheet = CssStyleSheetParser.Parse("h1 { color: navy; }");
+        var resolver = new CascadeResolver(new[] { sheet });
+
+        var h1 = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "h1");
+        var style = resolver.Resolve(h1, null);
+
+        style.Display.Should().Be("block"); // from UA
+        style.Color.Should().Be("navy"); // from author stylesheet
+        style.FontWeight.Should().Be("bold"); // from UA
+    }
+
+    [Fact]
+    public void Inheritance_WorksFromParent()
+    {
+        var doc = HtmlParser.Parse("<div style='color: purple'><span>text</span></div>");
+        var resolver = new CascadeResolver(Array.Empty<CssStyleSheet>());
+
+        var div = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "div");
+        var divStyle = resolver.Resolve(div, null);
+
+        var span = div.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "span");
+        var spanStyle = resolver.Resolve(span, divStyle);
+
+        spanStyle.Color.Should().Be("purple"); // inherited
+    }
+
+    [Fact]
+    public void NonMatchingRule_NotApplied()
+    {
+        var doc = HtmlParser.Parse("<p>Hello</p>");
+        var sheet = CssStyleSheetParser.Parse("h1 { color: red; }");
+        var resolver = new CascadeResolver(new[] { sheet });
+
+        var p = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "p");
+        var style = resolver.Resolve(p, null);
+
+        style.Color.Should().NotBe("red");
+    }
+
+    [Fact]
+    public void MediaPrint_Applied()
+    {
+        var doc = HtmlParser.Parse("<p>Hello</p>");
+        var sheet = CssStyleSheetParser.Parse("@media print { p { color: black; } }");
+        var resolver = new CascadeResolver(new[] { sheet }, mediaType: "print");
+
+        var p = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "p");
+        var style = resolver.Resolve(p, null);
+
+        style.Color.Should().Be("black");
+    }
+
+    [Fact]
+    public void MediaScreen_SkippedInPrintMode()
+    {
+        var doc = HtmlParser.Parse("<p>Hello</p>");
+        var sheet = CssStyleSheetParser.Parse("@media screen { p { color: green; } }");
+        var resolver = new CascadeResolver(new[] { sheet }, mediaType: "print");
+
+        var p = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "p");
+        var style = resolver.Resolve(p, null);
+
+        style.Color.Should().NotBe("green");
+    }
+
+    [Fact]
+    public void HiddenAttribute_DisplayNone()
+    {
+        var doc = HtmlParser.Parse("<div hidden>secret</div>");
+        var resolver = new CascadeResolver(Array.Empty<CssStyleSheet>());
+
+        var div = doc.Body!.ChildNodes.OfType<HtmlElement>().First();
+        var style = resolver.Resolve(div, null);
+
+        style.Display.Should().Be("none");
+    }
+
+    [Fact]
+    public void MultipleStylesheets_AllApplied()
+    {
+        var doc = HtmlParser.Parse("<p class='bold'>Hello</p>");
+        var sheet1 = CssStyleSheetParser.Parse("p { color: red; }");
+        var sheet2 = CssStyleSheetParser.Parse(".bold { font-weight: bold; }");
+        var resolver = new CascadeResolver(new[] { sheet1, sheet2 });
+
+        var p = doc.Body!.ChildNodes.OfType<HtmlElement>().First(e => e.TagName == "p");
+        var style = resolver.Resolve(p, null);
+
+        style.Color.Should().Be("red");
+        style.FontWeight.Should().Be("bold");
+    }
+}


### PR DESCRIPTION
## Summary
Phase 2 (CSS Foundation) is COMPLETE!

- CascadeResolver: UA defaults -> author stylesheets -> inline styles
- Specificity ordering, !important, source order
- @media print filtering (screen rules excluded in print mode)
- Multiple stylesheet support, inheritance
- 12 new tests, 201 total

## Phase 2 Acceptance
- [x] CSS tokenizer (Level 3)
- [x] CSS parser (rules, at-rules, declarations)
- [x] Selector engine (type, class, ID, combinators, pseudo-classes)
- [x] Cascade (specificity, !important, source order)
- [x] @media print handling

Closes #13 #14

Generated with [Claude Code](https://claude.com/claude-code)