### PR TITLE
feat: TrueType font parser (cmap, hmtx, glyph widths)

### DIFF
--- a/src/EggPdf.Text/Placeholder.cs
+++ b/src/EggPdf.Text/Placeholder.cs
@@ -1,1 +1,0 @@
-namespace EggPdf.Text; public static class Placeholder { }

--- a/src/EggPdf.Text/TrueType/FontData.cs
+++ b/src/EggPdf.Text/TrueType/FontData.cs
@@ -1,0 +1,79 @@
+namespace EggPdf.Text.TrueType;
+
+/// <summary>
+/// Parsed TrueType font data with metrics needed for text layout and PDF embedding.
+/// </summary>
+public class FontData
+{
+    /// <summary>Font family name (e.g., "Arial", "DejaVu Sans").</summary>
+    public string FamilyName { get; set; } = "";
+
+    /// <summary>Units per em (typically 1000 or 2048).</summary>
+    public int UnitsPerEm { get; set; }
+
+    /// <summary>Ascent in font units (positive, above baseline).</summary>
+    public int Ascent { get; set; }
+
+    /// <summary>Descent in font units (negative, below baseline).</summary>
+    public int Descent { get; set; }
+
+    /// <summary>Line gap in font units.</summary>
+    public int LineGap { get; set; }
+
+    /// <summary>Number of glyphs in the font.</summary>
+    public int NumGlyphs { get; set; }
+
+    /// <summary>Advance widths per glyph ID (in font units).</summary>
+    public ushort[] AdvanceWidths { get; set; } = System.Array.Empty<ushort>();
+
+    /// <summary>cmap: Unicode codepoint -> glyph ID mapping.</summary>
+    internal CmapData? Cmap { get; set; }
+
+    /// <summary>Raw font file bytes (for PDF embedding).</summary>
+    public byte[] RawData { get; set; } = System.Array.Empty<byte>();
+
+    /// <summary>Get glyph ID for a Unicode codepoint.</summary>
+    public ushort GetGlyphId(int codepoint)
+    {
+        return Cmap?.GetGlyphId(codepoint) ?? 0;
+    }
+
+    /// <summary>Get advance width for a glyph ID (in font units).</summary>
+    public ushort GetAdvanceWidth(ushort glyphId)
+    {
+        if (glyphId < AdvanceWidths.Length)
+            return AdvanceWidths[glyphId];
+        // Last width applies to remaining glyphs
+        return AdvanceWidths.Length > 0 ? AdvanceWidths[AdvanceWidths.Length - 1] : (ushort)0;
+    }
+
+    /// <summary>Measure text width in font units.</summary>
+    public int MeasureTextWidth(string text)
+    {
+        int width = 0;
+        foreach (char c in text)
+        {
+            var glyphId = GetGlyphId(c);
+            width += GetAdvanceWidth(glyphId);
+        }
+        return width;
+    }
+
+    /// <summary>Measure text width in pixels at a given font size.</summary>
+    public float MeasureTextWidthPx(string text, float fontSizePx)
+    {
+        if (UnitsPerEm == 0) return 0;
+        return MeasureTextWidth(text) * fontSizePx / UnitsPerEm;
+    }
+}
+
+/// <summary>Character-to-glyph mapping data.</summary>
+internal class CmapData
+{
+    private readonly System.Collections.Generic.Dictionary<int, ushort> _map = new();
+
+    public void Add(int codepoint, ushort glyphId) => _map[codepoint] = glyphId;
+
+    public ushort GetGlyphId(int codepoint)
+        => _map.TryGetValue(codepoint, out var id) ? id : (ushort)0;
+}

--- a/src/EggPdf.Text/TrueType/TtfParser.cs
+++ b/src/EggPdf.Text/TrueType/TtfParser.cs
@@ -1,0 +1,293 @@
+using System;
+
+namespace EggPdf.Text.TrueType;
+
+/// <summary>
+/// Parses TrueType font files (.ttf). Reads essential tables:
+/// head, hhea, maxp, hmtx, cmap, name.
+/// Returns null on invalid/empty input (infallible).
+/// </summary>
+public static class TtfParser
+{
+    public static FontData? Parse(byte[] data)
+    {
+        if (data == null || data.Length < 12)
+            return null;
+
+        try
+        {
+            return ParseInternal(data);
+        }
+        catch
+        {
+            return null; // infallible
+        }
+    }
+
+    private static FontData? ParseInternal(byte[] data)
+    {
+        int pos = 0;
+
+        // Offset table
+        uint sfVersion = ReadUInt32(data, ref pos);
+        // Accept TrueType (0x00010000) or OpenType ('OTTO')
+        if (sfVersion != 0x00010000 && sfVersion != 0x4F54544F)
+            return null;
+
+        ushort numTables = ReadUInt16(data, ref pos);
+        pos += 6; // skip searchRange, entrySelector, rangeShift
+
+        // Read table directory
+        var tables = new System.Collections.Generic.Dictionary<string, (uint offset, uint length)>();
+        for (int i = 0; i < numTables; i++)
+        {
+            string tag = ReadTag(data, ref pos);
+            pos += 4; // skip checksum
+            uint offset = ReadUInt32(data, ref pos);
+            uint length = ReadUInt32(data, ref pos);
+            tables[tag] = (offset, length);
+        }
+
+        var font = new FontData { RawData = data };
+
+        // Parse head table
+        if (tables.TryGetValue("head", out var head))
+            ParseHead(data, (int)head.offset, font);
+
+        // Parse hhea table
+        if (tables.TryGetValue("hhea", out var hhea))
+            ParseHhea(data, (int)hhea.offset, font);
+
+        // Parse maxp table
+        if (tables.TryGetValue("maxp", out var maxp))
+            ParseMaxp(data, (int)maxp.offset, font);
+
+        // Parse hmtx table (needs hhea.numberOfHMetrics and maxp.numGlyphs)
+        if (tables.TryGetValue("hmtx", out var hmtx))
+            ParseHmtx(data, (int)hmtx.offset, font);
+
+        // Parse cmap table
+        if (tables.TryGetValue("cmap", out var cmap))
+            ParseCmap(data, (int)cmap.offset, font);
+
+        // Parse name table
+        if (tables.TryGetValue("name", out var name))
+            ParseName(data, (int)name.offset, (int)name.length, font);
+
+        return font;
+    }
+
+    private static void ParseHead(byte[] data, int offset, FontData font)
+    {
+        // head table: version(4), fontRevision(4), checksumAdjust(4), magicNumber(4),
+        // flags(2), unitsPerEm(2), ...
+        int pos = offset + 18; // skip to unitsPerEm
+        font.UnitsPerEm = ReadUInt16(data, ref pos);
+    }
+
+    private static int _numberOfHMetrics;
+
+    private static void ParseHhea(byte[] data, int offset, FontData font)
+    {
+        int pos = offset + 4; // skip version
+        font.Ascent = ReadInt16(data, ref pos);
+        font.Descent = ReadInt16(data, ref pos);
+        font.LineGap = ReadInt16(data, ref pos);
+
+        // Skip to numberOfHMetrics (at offset+34)
+        pos = offset + 34;
+        _numberOfHMetrics = ReadUInt16(data, ref pos);
+    }
+
+    private static void ParseMaxp(byte[] data, int offset, FontData font)
+    {
+        int pos = offset + 4; // skip version
+        font.NumGlyphs = ReadUInt16(data, ref pos);
+    }
+
+    private static void ParseHmtx(byte[] data, int offset, FontData font)
+    {
+        // Each longHorMetric: advanceWidth(2) + lsb(2)
+        int numMetrics = _numberOfHMetrics;
+        font.AdvanceWidths = new ushort[font.NumGlyphs];
+
+        int pos = offset;
+        ushort lastWidth = 0;
+
+        for (int i = 0; i < numMetrics && i < font.NumGlyphs; i++)
+        {
+            if (pos + 4 > data.Length) break;
+            lastWidth = ReadUInt16(data, ref pos);
+            font.AdvanceWidths[i] = lastWidth;
+            pos += 2; // skip lsb
+        }
+
+        // Remaining glyphs use the last advance width
+        for (int i = numMetrics; i < font.NumGlyphs; i++)
+            font.AdvanceWidths[i] = lastWidth;
+    }
+
+    private static void ParseCmap(byte[] data, int offset, FontData font)
+    {
+        font.Cmap = new CmapData();
+
+        int pos = offset;
+        pos += 2; // skip version
+
+        ushort numSubtables = ReadUInt16(data, ref pos);
+
+        // Find a Unicode subtable (platformID 0 or 3)
+        int bestOffset = -1;
+        for (int i = 0; i < numSubtables; i++)
+        {
+            ushort platformID = ReadUInt16(data, ref pos);
+            ushort encodingID = ReadUInt16(data, ref pos);
+            uint subtableOffset = ReadUInt32(data, ref pos);
+
+            if (platformID == 0 || (platformID == 3 && (encodingID == 1 || encodingID == 10)))
+            {
+                bestOffset = offset + (int)subtableOffset;
+            }
+        }
+
+        if (bestOffset < 0) return;
+
+        // Read subtable format
+        int subPos = bestOffset;
+        ushort format = ReadUInt16(data, ref subPos);
+
+        if (format == 4)
+            ParseCmapFormat4(data, bestOffset, font.Cmap);
+        // Format 12 support can be added later for supplementary planes
+    }
+
+    private static void ParseCmapFormat4(byte[] data, int offset, CmapData cmap)
+    {
+        int pos = offset + 2; // skip format
+        ushort length = ReadUInt16(data, ref pos);
+        pos += 2; // skip language
+        ushort segCount2 = ReadUInt16(data, ref pos);
+        int segCount = segCount2 / 2;
+        pos += 6; // skip searchRange, entrySelector, rangeShift
+
+        var endCodes = new ushort[segCount];
+        for (int i = 0; i < segCount; i++)
+            endCodes[i] = ReadUInt16(data, ref pos);
+
+        pos += 2; // reservedPad
+
+        var startCodes = new ushort[segCount];
+        for (int i = 0; i < segCount; i++)
+            startCodes[i] = ReadUInt16(data, ref pos);
+
+        var idDeltas = new short[segCount];
+        for (int i = 0; i < segCount; i++)
+            idDeltas[i] = ReadInt16(data, ref pos);
+
+        int idRangeOffsetsStart = pos;
+        var idRangeOffsets = new ushort[segCount];
+        for (int i = 0; i < segCount; i++)
+            idRangeOffsets[i] = ReadUInt16(data, ref pos);
+
+        // Map codepoints to glyph IDs
+        for (int seg = 0; seg < segCount; seg++)
+        {
+            if (startCodes[seg] == 0xFFFF) break;
+
+            for (int cp = startCodes[seg]; cp <= endCodes[seg]; cp++)
+            {
+                ushort glyphId;
+                if (idRangeOffsets[seg] == 0)
+                {
+                    glyphId = (ushort)((cp + idDeltas[seg]) & 0xFFFF);
+                }
+                else
+                {
+                    int glyphIdOffset = idRangeOffsetsStart + seg * 2 + idRangeOffsets[seg]
+                        + (cp - startCodes[seg]) * 2;
+                    if (glyphIdOffset + 2 > data.Length) continue;
+                    int rawPos = glyphIdOffset;
+                    glyphId = ReadUInt16(data, ref rawPos);
+                    if (glyphId != 0)
+                        glyphId = (ushort)((glyphId + idDeltas[seg]) & 0xFFFF);
+                }
+
+                if (glyphId != 0)
+                    cmap.Add(cp, glyphId);
+            }
+        }
+    }
+
+    private static void ParseName(byte[] data, int offset, int tableLength, FontData font)
+    {
+        if (offset + 6 > data.Length) return;
+
+        int pos = offset;
+        pos += 2; // format
+        ushort count = ReadUInt16(data, ref pos);
+        ushort stringOffset = ReadUInt16(data, ref pos);
+        int storageStart = offset + stringOffset;
+
+        for (int i = 0; i < count; i++)
+        {
+            if (pos + 12 > data.Length) break;
+
+            ushort platformID = ReadUInt16(data, ref pos);
+            ushort encodingID = ReadUInt16(data, ref pos);
+            ushort languageID = ReadUInt16(data, ref pos);
+            ushort nameID = ReadUInt16(data, ref pos);
+            ushort nameLength = ReadUInt16(data, ref pos);
+            ushort nameOffset = ReadUInt16(data, ref pos);
+
+            // nameID 1 = Font Family
+            if (nameID == 1 && string.IsNullOrEmpty(font.FamilyName))
+            {
+                int nameStart = storageStart + nameOffset;
+                if (nameStart + nameLength <= data.Length)
+                {
+                    if (platformID == 3 || platformID == 0)
+                    {
+                        // UTF-16 BE
+                        font.FamilyName = System.Text.Encoding.BigEndianUnicode.GetString(data, nameStart, nameLength);
+                    }
+                    else
+                    {
+                        // ASCII/Latin
+                        font.FamilyName = System.Text.Encoding.ASCII.GetString(data, nameStart, nameLength);
+                    }
+                }
+            }
+        }
+    }
+
+    // Binary readers (big-endian)
+    private static ushort ReadUInt16(byte[] data, ref int pos)
+    {
+        if (pos + 2 > data.Length) { pos += 2; return 0; }
+        ushort val = (ushort)((data[pos] << 8) | data[pos + 1]);
+        pos += 2;
+        return val;
+    }
+
+    private static short ReadInt16(byte[] data, ref int pos)
+    {
+        return (short)ReadUInt16(data, ref pos);
+    }
+
+    private static uint ReadUInt32(byte[] data, ref int pos)
+    {
+        if (pos + 4 > data.Length) { pos += 4; return 0; }
+        uint val = ((uint)data[pos] << 24) | ((uint)data[pos + 1] << 16) |
+                   ((uint)data[pos + 2] << 8) | data[pos + 3];
+        pos += 4;
+        return val;
+    }
+
+    private static string ReadTag(byte[] data, ref int pos)
+    {
+        if (pos + 4 > data.Length) { pos += 4; return ""; }
+        var tag = System.Text.Encoding.ASCII.GetString(data, pos, 4);
+        pos += 4;
+        return tag;
+    }
+}

--- a/tests/EggPdf.Tests.Unit/Text/TrueTypeParserTests.cs
+++ b/tests/EggPdf.Tests.Unit/Text/TrueTypeParserTests.cs
@@ -1,0 +1,127 @@
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using EggPdf.Text.TrueType;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Text;
+
+public class TrueTypeParserTests
+{
+    private static string? FindSystemFont(string name)
+    {
+        string[] searchPaths;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            searchPaths = new[] { @"C:\Windows\Fonts" };
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            searchPaths = new[] { "/System/Library/Fonts", "/Library/Fonts" };
+        else
+            searchPaths = new[] { "/usr/share/fonts", "/usr/local/share/fonts" };
+
+        foreach (var dir in searchPaths)
+        {
+            if (!Directory.Exists(dir)) continue;
+            try
+            {
+                var files = Directory.GetFiles(dir, "*.ttf", SearchOption.AllDirectories);
+                var match = files.FirstOrDefault(f => Path.GetFileNameWithoutExtension(f)
+                    .IndexOf(name, System.StringComparison.OrdinalIgnoreCase) >= 0);
+                if (match != null) return match;
+            }
+            catch { /* permission denied etc */ }
+        }
+        return null;
+    }
+
+    private static FontData? LoadTestFont()
+    {
+        var path = FindSystemFont("arial") ?? FindSystemFont("DejaVuSans") ?? FindSystemFont("Liberation");
+        if (path == null) return null;
+        return TtfParser.Parse(File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void ParseSystemFont_ReadsHeadTable()
+    {
+        var font = LoadTestFont();
+        if (font == null) return; // skip if no font available
+
+        font.UnitsPerEm.Should().BeGreaterThan(0);
+        font.Ascent.Should().BeGreaterThan(0);
+        font.Descent.Should().BeLessThan(0);
+    }
+
+    [Fact]
+    public void ParseSystemFont_HasGlyphCount()
+    {
+        var font = LoadTestFont();
+        if (font == null) return;
+
+        font.NumGlyphs.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void ParseSystemFont_MapsAsciiGlyphs()
+    {
+        var font = LoadTestFont();
+        if (font == null) return;
+
+        font.GetGlyphId('A').Should().BeGreaterThan(0);
+        font.GetGlyphId(' ').Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void ParseSystemFont_GlyphWidths()
+    {
+        var font = LoadTestFont();
+        if (font == null) return;
+
+        var aWidth = font.GetAdvanceWidth(font.GetGlyphId('A'));
+        aWidth.Should().BeGreaterThan(0);
+
+        var iWidth = font.GetAdvanceWidth(font.GetGlyphId('i'));
+        var mWidth = font.GetAdvanceWidth(font.GetGlyphId('M'));
+        iWidth.Should().BeLessThan(mWidth);
+    }
+
+    [Fact]
+    public void ParseSystemFont_FontName()
+    {
+        var font = LoadTestFont();
+        if (font == null) return;
+
+        font.FamilyName.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void ParseSystemFont_MeasureText()
+    {
+        var font = LoadTestFont();
+        if (font == null) return;
+
+        float width = font.MeasureTextWidthPx("Hello", 16);
+        width.Should().BeGreaterThan(0);
+
+        float widerWidth = font.MeasureTextWidthPx("Hello World", 16);
+        widerWidth.Should().BeGreaterThan(width);
+    }
+
+    [Fact]
+    public void Parse_EmptyData_ReturnsNull()
+    {
+        TtfParser.Parse(new byte[0]).Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_InvalidData_ReturnsNull()
+    {
+        TtfParser.Parse(new byte[] { 0, 1, 2, 3 }).Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_NullData_ReturnsNull()
+    {
+        TtfParser.Parse(null!).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Parse TrueType (.ttf) binary font files
- Tables: head, hhea, maxp, hmtx, cmap (format 4), name
- Glyph ID lookup, advance widths, text measurement
- Infallible: null on invalid input
- 9 new tests, 223 total

Closes #16

Generated with [Claude Code](https://claude.com/claude-code)