### PR TITLE
fix: mobile nav and iPhone SE layout

### DIFF
--- a/site/architecture.html
+++ b/site/architecture.html
@@ -24,6 +24,7 @@
       </svg>
       <span class="logo-text">Egg<span class="logo-accent">Pdf</span></span>
     </a>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false"><svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="5" x2="19" y2="5"/><line x1="3" y1="11" x2="19" y2="11"/><line x1="3" y1="17" x2="19" y2="17"/></svg></button>
     <nav class="nav-links" aria-label="Main navigation">
       <a href="getting-started.html">Docs</a>
       <a href="docker.html">Docker</a>
@@ -270,5 +271,21 @@
   </div>
 </footer>
 
+<script>
+(function() {
+  var btn = document.querySelector(".nav-hamburger");
+  var nav = document.querySelector(".nav-links");
+  btn.addEventListener("click", function() {
+    var open = nav.classList.toggle("open");
+    btn.setAttribute("aria-expanded", open);
+  });
+  document.addEventListener("click", function(e) {
+    if (!e.target.closest(".nav")) {
+      nav.classList.remove("open");
+      btn.setAttribute("aria-expanded", "false");
+    }
+  });
+})();
+</script>
 </body>
 </html>

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -536,6 +536,10 @@ td a.dl-link:hover { background: #FDE68A; text-decoration: none; }
   border: none;
   cursor: pointer;
   padding: 6px;
+  min-width: 44px;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
   color: var(--text);
   border-radius: 6px;
   transition: background .15s;
@@ -545,14 +549,15 @@ td a.dl-link:hover { background: #FDE68A; text-decoration: none; }
 
 /* ── Responsive ──────────────────────────────────────────────── */
 @media (max-width: 768px) {
-  .nav-hamburger { display: flex; align-items: center; }
+  .nav { position: relative; }
+  .nav-hamburger { display: flex; }
   .nav-links {
     display: none;
     position: absolute;
-    top: 100%;
+    top: var(--nav-height);
     left: 0;
     right: 0;
-    z-index: 50;
+    z-index: 200;
     background: #fff;
     border-top: 1px solid var(--border);
     box-shadow: 0 4px 12px rgba(0,0,0,.1);
@@ -562,19 +567,24 @@ td a.dl-link:hover { background: #FDE68A; text-decoration: none; }
   }
   .nav-links.open { display: flex; }
   .nav-links a {
-    padding: 0.65rem 0;
+    padding: 0.75rem 0;
     font-size: 1rem;
     border-bottom: 1px solid #f3f4f6;
     border-radius: 0;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
   }
   .nav-links a:last-child { border-bottom: none; }
-  .nav-links a.nav-github { margin-top: 0.25rem; text-align: center; }
+  .nav-links a.nav-github { margin-top: 0.25rem; justify-content: center; }
 
-  .hero { padding: 80px 0 56px; }
+  .hero { padding: 60px 0 44px; }
   .benchmark-cards { grid-template-columns: 1fr; gap: 1rem; }
   .features-grid { grid-template-columns: 1fr; }
   .code-example { grid-template-columns: 1fr; gap: 2rem; }
-  .section { padding: 56px 0; }
+  .section { padding: 48px 0; }
+  .install-section { padding: 48px 0; }
+  .page-header { padding: 40px 0 28px; }
 
   .docs-layout { grid-template-columns: 1fr; }
   .docs-sidebar {
@@ -593,6 +603,19 @@ td a.dl-link:hover { background: #FDE68A; text-decoration: none; }
   }
   .docs-sidebar a { padding: 2px 0; }
 }
+
+/* ── Extra-small screens (iPhone SE: 375px) ──────────────────── */
+@media (max-width: 480px) {
+  .container { padding: 0 1rem; }
+  .tab-btn { padding: 8px 10px; font-size: 0.82rem; }
+  .btn { padding: 12px 20px; font-size: 0.9rem; }
+  .hero h1 { font-size: 2rem; }
+  .hero-subtitle { font-size: 1rem; }
+  .benchmark-value { font-size: 1.75rem; }
+  .section-heading h2 { font-size: 1.5rem; }
+  .install-section h2 { font-size: 1.5rem; }
+}
+
 @media (min-width: 769px) and (max-width: 1024px) {
   .features-grid { grid-template-columns: repeat(2, 1fr); }
   .benchmark-cards { grid-template-columns: repeat(3, 1fr); }

--- a/site/configuration.html
+++ b/site/configuration.html
@@ -25,6 +25,7 @@
       </svg>
       <span class="logo-text">Egg<span class="logo-accent">Pdf</span></span>
     </a>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false"><svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="5" x2="19" y2="5"/><line x1="3" y1="11" x2="19" y2="11"/><line x1="3" y1="17" x2="19" y2="17"/></svg></button>
     <nav class="nav-links" aria-label="Main navigation">
       <a href="getting-started.html">Docs</a>
       <a href="docker.html">Docker</a>
@@ -187,5 +188,21 @@
   </div>
 </footer>
 
+<script>
+(function() {
+  var btn = document.querySelector(".nav-hamburger");
+  var nav = document.querySelector(".nav-links");
+  btn.addEventListener("click", function() {
+    var open = nav.classList.toggle("open");
+    btn.setAttribute("aria-expanded", open);
+  });
+  document.addEventListener("click", function(e) {
+    if (!e.target.closest(".nav")) {
+      nav.classList.remove("open");
+      btn.setAttribute("aria-expanded", "false");
+    }
+  });
+})();
+</script>
 </body>
 </html>

--- a/site/fonts.html
+++ b/site/fonts.html
@@ -24,6 +24,7 @@
       </svg>
       <span class="logo-text">Egg<span class="logo-accent">Pdf</span></span>
     </a>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false"><svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="5" x2="19" y2="5"/><line x1="3" y1="11" x2="19" y2="11"/><line x1="3" y1="17" x2="19" y2="17"/></svg></button>
     <nav class="nav-links" aria-label="Main navigation">
       <a href="getting-started.html">Docs</a>
       <a href="docker.html">Docker</a>
@@ -161,5 +162,21 @@
   </div>
 </footer>
 
+<script>
+(function() {
+  var btn = document.querySelector(".nav-hamburger");
+  var nav = document.querySelector(".nav-links");
+  btn.addEventListener("click", function() {
+    var open = nav.classList.toggle("open");
+    btn.setAttribute("aria-expanded", open);
+  });
+  document.addEventListener("click", function(e) {
+    if (!e.target.closest(".nav")) {
+      nav.classList.remove("open");
+      btn.setAttribute("aria-expanded", "false");
+    }
+  });
+})();
+</script>
 </body>
 </html>

--- a/site/headers-footers.html
+++ b/site/headers-footers.html
@@ -24,6 +24,7 @@
       </svg>
       <span class="logo-text">Egg<span class="logo-accent">Pdf</span></span>
     </a>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false"><svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="5" x2="19" y2="5"/><line x1="3" y1="11" x2="19" y2="11"/><line x1="3" y1="17" x2="19" y2="17"/></svg></button>
     <nav class="nav-links" aria-label="Main navigation">
       <a href="getting-started.html">Docs</a>
       <a href="docker.html">Docker</a>
@@ -176,5 +177,21 @@
   </div>
 </footer>
 
+<script>
+(function() {
+  var btn = document.querySelector(".nav-hamburger");
+  var nav = document.querySelector(".nav-links");
+  btn.addEventListener("click", function() {
+    var open = nav.classList.toggle("open");
+    btn.setAttribute("aria-expanded", open);
+  });
+  document.addEventListener("click", function(e) {
+    if (!e.target.closest(".nav")) {
+      nav.classList.remove("open");
+      btn.setAttribute("aria-expanded", "false");
+    }
+  });
+})();
+</script>
 </body>
 </html>

--- a/site/page-layout.html
+++ b/site/page-layout.html
@@ -25,6 +25,7 @@
       </svg>
       <span class="logo-text">Egg<span class="logo-accent">Pdf</span></span>
     </a>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false"><svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="5" x2="19" y2="5"/><line x1="3" y1="11" x2="19" y2="11"/><line x1="3" y1="17" x2="19" y2="17"/></svg></button>
     <nav class="nav-links" aria-label="Main navigation">
       <a href="getting-started.html">Docs</a>
       <a href="docker.html">Docker</a>
@@ -174,5 +175,21 @@
   </div>
 </footer>
 
+<script>
+(function() {
+  var btn = document.querySelector(".nav-hamburger");
+  var nav = document.querySelector(".nav-links");
+  btn.addEventListener("click", function() {
+    var open = nav.classList.toggle("open");
+    btn.setAttribute("aria-expanded", open);
+  });
+  document.addEventListener("click", function(e) {
+    if (!e.target.closest(".nav")) {
+      nav.classList.remove("open");
+      btn.setAttribute("aria-expanded", "false");
+    }
+  });
+})();
+</script>
 </body>
 </html>

--- a/site/performance.html
+++ b/site/performance.html
@@ -24,6 +24,7 @@
       </svg>
       <span class="logo-text">Egg<span class="logo-accent">Pdf</span></span>
     </a>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false"><svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="5" x2="19" y2="5"/><line x1="3" y1="11" x2="19" y2="11"/><line x1="3" y1="17" x2="19" y2="17"/></svg></button>
     <nav class="nav-links" aria-label="Main navigation">
       <a href="getting-started.html">Docs</a>
       <a href="docker.html">Docker</a>
@@ -184,5 +185,21 @@
   </div>
 </footer>
 
+<script>
+(function() {
+  var btn = document.querySelector(".nav-hamburger");
+  var nav = document.querySelector(".nav-links");
+  btn.addEventListener("click", function() {
+    var open = nav.classList.toggle("open");
+    btn.setAttribute("aria-expanded", open);
+  });
+  document.addEventListener("click", function(e) {
+    if (!e.target.closest(".nav")) {
+      nav.classList.remove("open");
+      btn.setAttribute("aria-expanded", "false");
+    }
+  });
+})();
+</script>
 </body>
 </html>

--- a/site/tables.html
+++ b/site/tables.html
@@ -25,6 +25,7 @@
       </svg>
       <span class="logo-text">Egg<span class="logo-accent">Pdf</span></span>
     </a>
+    <button class="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false"><svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="5" x2="19" y2="5"/><line x1="3" y1="11" x2="19" y2="11"/><line x1="3" y1="17" x2="19" y2="17"/></svg></button>
     <nav class="nav-links" aria-label="Main navigation">
       <a href="getting-started.html">Docs</a>
       <a href="docker.html">Docker</a>
@@ -176,5 +177,21 @@
   </div>
 </footer>
 
+<script>
+(function() {
+  var btn = document.querySelector(".nav-hamburger");
+  var nav = document.querySelector(".nav-links");
+  btn.addEventListener("click", function() {
+    var open = nav.classList.toggle("open");
+    btn.setAttribute("aria-expanded", open);
+  });
+  document.addEventListener("click", function(e) {
+    if (!e.target.closest(".nav")) {
+      nav.classList.remove("open");
+      btn.setAttribute("aria-expanded", "false");
+    }
+  });
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Add missing hamburger nav button + JS to 7 pages that didn't have it: `architecture`, `fonts`, `configuration`, `tables`, `page-layout`, `performance`, `headers-footers` — on mobile these pages had no way to navigate
- Fix nav dropdown positioning: use `position: relative` on `.nav` and `top: var(--nav-height)` instead of `top: 100%` so it works reliably on sticky nav in all browsers
- Raise dropdown z-index to 200 so it layers above page content
- Increase hamburger and nav link touch targets to 44×44px (Apple HIG minimum)

## iPhone SE (375px) fixes

- Add `@media (max-width: 480px)` block: reduce tab button padding so 4 CLI OS tabs fit on one row, tighter section padding, smaller hero h1 (2rem), smaller buttons

## Test plan

- [ ] Open each docs page on iPhone SE (375px) — hamburger button visible in nav
- [ ] Tap hamburger — dropdown opens full-width below nav bar
- [ ] Tap outside nav — dropdown closes
- [ ] On index.html: CLI tab → OS sub-tabs fit on one line without wrapping
- [ ] Desktop (>768px) — hamburger hidden, nav links visible as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)