### PR TITLE
chore: add dual-perspective /review skill

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,46 +1,131 @@
 ---
 name: review
-description: Review code changes for bugs, regressions, and quality. Run tests and analyze diffs.
-allowed-tools: Bash(dotnet *), Bash(git *), Read, Grep, Glob, Agent
+description: Dual-perspective code review — Lead Dev (architecture/correctness) + Dev (implementation/tests). Runs entirely in the main agent for easy follow-up.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Glob, TodoWrite
 ---
 
-# Code Review
+# Code Review — Lead Dev + Dev Perspectives
 
-Review recent code changes for correctness, quality, and regressions.
+Review the current branch diff from two perspectives in sequence. Everything runs in the main agent — no subagents — so you can ask follow-up questions about any finding.
 
-## Steps
+## Arguments
 
-1. **Check what changed**
-   ```bash
-   git diff --stat HEAD~1
-   git diff HEAD~1
-   ```
+- `$ARGUMENTS` — optional: specific commit range or file to focus on (default: HEAD~1..HEAD, or all commits ahead of main)
 
-2. **Run the full test suite**
-   ```bash
-   dotnet test tests/EggPdf.Tests.Unit -c Release
-   dotnet test tests/EggPdf.Tests.Layout -c Release
-   ```
+## Step 1: Gather context
 
-3. **Review each changed file** for:
-   - Logic bugs (off-by-one, null refs, wrong comparisons)
-   - Performance regressions (LINQ in hot paths, unnecessary allocations)
-   - Missing error handling at system boundaries
-   - Broken netstandard2.0 compatibility (no `record`, no `Span.Contains`, use `IndexOf` not `Contains(string, StringComparison)`)
-   - Dead code or unused imports
-   - Missing test coverage for new behavior
+```bash
+# What commits are on this branch vs main?
+git log main..HEAD --oneline
 
-4. **Check PDF output** for any template that uses the changed code paths:
-   ```bash
-   # Start service if not running
-   curl -s http://localhost:55727/health || dotnet run --project src/EggPdf.Service -c Release -- --urls http://localhost:55727 &
-   sleep 5
-   # Render a test PDF and verify content stream
-   curl -s -X POST http://localhost:55727/api/render -H "Content-Type: application/json" \
-     -d '{"html":"<html><body><h1>Test</h1><p>Hello</p></body></html>"}' | sed -n '/^stream$/,/^endstream$/p'
-   ```
+# Full diff for the branch
+git diff main..HEAD
 
-5. **Report findings** with:
-   - List of issues found (severity: critical/moderate/minor)
-   - Suggested fixes
-   - Overall approval status (approve/request-changes)
+# Which files changed?
+git diff --stat main..HEAD
+```
+
+If `$ARGUMENTS` specifies a range or file, use that instead.
+
+## Step 2: Run the test suite
+
+```bash
+dotnet test tests/EggPdf.Tests.Unit -c Release
+dotnet test tests/EggPdf.Tests.Layout -c Release
+```
+
+Report pass/fail counts. Stop and surface any failures before continuing.
+
+## Step 3: 🔵 LEAD DEV REVIEW
+
+Think like a senior engineer who owns the architecture. Read every changed file carefully.
+
+Check for:
+
+**Correctness & Spec compliance**
+- Does the logic match the CSS/PDF spec? (cite spec if relevant)
+- Off-by-one errors, wrong comparisons, missed edge cases
+- Incorrect coordinate system assumptions (px vs pt, top-origin vs bottom-origin)
+- PDF operator semantics (persistent state, BT/ET scope, graphics state stack)
+
+**Architecture & design**
+- Does the change fit the 8-stage pipeline model (Parse → Style → Layout → Paint → PDF)?
+- Does it belong in the right project (`EggPdf.Layout` vs `EggPdf.Pdf` vs `EggPdf` etc.)?
+- Does it introduce unnecessary coupling or violate zero-dependency rule?
+- Is it the right abstraction, or is there a simpler/more robust approach?
+
+**Regressions**
+- Could this change silently break other layout paths (flex, table, block, inline)?
+- Does it affect hot paths? (check for LINQ, allocations, repeated work)
+
+**netstandard2.0 compatibility**
+- No `record` types, no `Span<T>.Contains`, no `Contains(string, StringComparison)` → use `IndexOf`
+- No C# features unavailable on netstandard2.0 without `#if`
+
+Present findings as:
+```
+🔵 LEAD DEV
+─────────────────────────────
+CRITICAL  — [file:line] description
+MODERATE  — [file:line] description
+MINOR     — [file:line] description
+APPROVED  — areas that look solid
+```
+
+## Step 4: 🟢 DEV REVIEW
+
+Think like the developer who will maintain this code day-to-day.
+
+Check for:
+
+**Test quality**
+- Are new behaviors covered by tests?
+- Do tests prove the bug existed before the fix (failing test first)?
+- Are test names descriptive (`Feature_Condition_ExpectedBehavior`)?
+- Any tests that could pass vacuously (assert nothing meaningful)?
+
+**Code clarity**
+- Is the logic easy to follow without comments?
+- Are variable names clear?
+- Is there dead code, unused imports, or orphaned helpers?
+- Are comments added only where logic is non-obvious?
+
+**Implementation details**
+- Does the fix address root cause or just symptom?
+- Any magic numbers that should be named constants?
+- Edge cases handled (null, empty, zero, negative)?
+
+**Consistency**
+- Does the style match surrounding code?
+- Same patterns used for similar problems elsewhere in the codebase?
+
+Present findings as:
+```
+🟢 DEV
+─────────────────────────────
+ISSUE     — [file:line] description
+SUGGESTION — [file:line] description
+LOOKS GOOD — areas that are well done
+```
+
+## Step 5: Summary verdict
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+REVIEW VERDICT
+──────────────
+Tests:      ✅ N passed / ❌ N failed
+Lead Dev:   ✅ APPROVED / ⚠️ CHANGES REQUESTED / ❌ BLOCKED
+Dev:        ✅ APPROVED / ⚠️ CHANGES REQUESTED
+
+Blockers (must fix before merge):
+  1. ...
+
+Suggestions (nice to have):
+  1. ...
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Stay in the main agent throughout. After the review, the user can ask follow-up questions or request fixes on any specific finding.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ dotnet run --project src/EggPdf.Service -c Release -- --urls http://localhost:55
 - `/ship` -- create PR with test + perf evidence
 - `/fix` -- fix a bug (reproduce with test first)
 - `/render-debug` -- trace a rendering issue through the pipeline
+- `/review` -- dual-perspective code review: Lead Dev (architecture/correctness) + Dev (implementation/tests), runs in main agent for easy follow-up
 
 ## Key Files
 


### PR DESCRIPTION
## Summary

- Rewrites `.claude/skills/review/SKILL.md` to run two sequential reviews entirely in the main agent (no subagents), making findings easy to follow up on
- **🔵 Lead Dev** perspective: architecture fit, CSS/PDF spec correctness, regression risk, netstandard2.0 compat, hot-path concerns
- **🟢 Dev** perspective: test quality, code clarity, dead code, implementation details, consistency
- Outputs a structured verdict: `APPROVED / CHANGES REQUESTED / BLOCKED` with blockers and suggestions
- Updated `CLAUDE.md` skills list to document `/review`

## Test plan

- [ ] Invoke `/review` on any branch with changes and verify the two-perspective output appears in the main conversation thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)