### PR TITLE
chore: bump GitHub Pages version badge to v1.3.0

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -75,7 +75,7 @@
 <!-- Hero -->
 <section class="hero">
   <div class="container">
-    <div class="hero-badge">v1.2.0 — MIT License</div>
+    <div class="hero-badge">v1.3.0 — MIT License</div>
     <h1>Zero-dependency HTML to<br><span class="accent">PDF for .NET</span></h1>
     <p class="hero-subtitle">Pure C# &nbsp;•&nbsp; MIT License &nbsp;•&nbsp; Chrome-quality output</p>
     <div class="hero-cta">


### PR DESCRIPTION
## Summary
- The `update-site-version` CI job failed during the v1.3.0 release (detached HEAD issue — since fixed), leaving `site/index.html` stuck at `v1.2.0`
- This PR manually bumps the hero badge to `v1.3.0`

## Test plan
- [ ] Merge triggers `pages.yml` (watches `site/**`) → GitHub Pages redeploys with the correct version badge