### PR TITLE
chore: remove version from GitHub Pages hero badge

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 jobs:
   build-cli:
@@ -104,29 +102,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-
-  update-site-version:
-    name: Update GitHub Pages version badge
-    needs: attach-to-release
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: main
-
-      - name: Update version badge in site/index.html
-        run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          sed -i "s|<div class=\"hero-badge\">v[^<]*</div>|<div class=\"hero-badge\">${TAG} — MIT License</div>|" site/index.html
-
-      - name: Commit updated site
-        run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add site/index.html
-          git diff --cached --quiet || git commit -m "chore: bump site version badge to ${TAG} [skip ci]"
-          git push origin main

--- a/site/index.html
+++ b/site/index.html
@@ -75,7 +75,7 @@
 <!-- Hero -->
 <section class="hero">
   <div class="container">
-    <div class="hero-badge">v1.3.1 — MIT License</div>
+    <div class="hero-badge">MIT License</div>
     <h1>Zero-dependency HTML to<br><span class="accent">PDF for .NET</span></h1>
     <p class="hero-subtitle">Pure C# &nbsp;•&nbsp; MIT License &nbsp;•&nbsp; Chrome-quality output</p>
     <div class="hero-cta">


### PR DESCRIPTION
## Summary
- Version badge kept going stale between releases (race conditions, detached HEAD issues, etc.)
- Simplest fix: remove the version number entirely — the badge now just says **MIT License**
- Also removes the `update-site-version` CI job and its associated permissions since they're no longer needed

## Test plan
- [ ] Merge triggers `pages.yml` → site redeploys with badge showing "MIT License" (no version number)