### PR TITLE
Chrome print parity: Unicode webfonts, layout fixes, PKI signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,4 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+test_local/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,28 +23,29 @@ See `design/architecture/` for detailed component specs (8 docs, ~3,000 lines).
 5. **Infallible parsers** -- HTML/CSS parsers never throw. Produce error nodes / silently ignore.
 6. **Graceful degradation** -- unknown CSS ignored, missing resources produce warnings not crashes.
 
-## Development Workflow (STRICT — TDD)
+## Development Workflow (STRICT — batched TDD)
 
-Every code change follows this TDD loop. **Do not skip steps.**
+Tests are still written before the code they cover, but execution is batched:
+write ALL the code for the task first, then run the test suite and fix.
+**Do not run tests or builds between individual edits mid-batch.**
 
 ```
-1. Write test  →  must FAIL (proves the test is testing something real)
-2. Write minimal code to make it pass
-3. Run the test
-   - FAIL → fix code, go back to step 3
+1. Write failing tests for every change in the batch
+2. Write all the code for the batch
+3. Run ALL tests (this also compiles — no separate build step)
+   - FAIL → fix code, run again; iterate until green
    - PASS → continue
-4. Run ALL tests
-   - FAIL (regression) → fix code, go back to step 4
-   - PASS → continue
-5. Benchmark if hot path (no regressions allowed)
-6. Commit with conventional prefix
+4. Benchmark if hot path (no regressions allowed)
+5. Commit with conventional prefix
 ```
 
 **Rules:**
-- Never write code before writing the test.
+- Never write code before writing the test that covers it.
 - Never commit with failing tests.
 - Never skip benchmarks for hot-path changes.
 - Keep iterating fix → run → fix until all tests pass — do not give up early.
+- Write the whole batch of code first, THEN run tests once and fix failures — no test runs after every small edit.
+- No standalone `dotnet build` — `dotnet test` compiles everything it needs. Only build separately when diagnosing a build-system issue itself.
 
 ## Conventional Commits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ src/
   EggPdf.Css/          -- CSS parser + cascade + selectors + inline parser
   EggPdf.Layout/       -- layout engine (block, inline, flex, table cells horizontal)
   EggPdf.Text/         -- TrueType parser, system font discovery, line breaking, font resolver
-  EggPdf.Pdf/          -- PDF 1.7 writer (text, rectangles, rounded rects, links, multi-page, PNG/JPEG images)
+  EggPdf.Pdf/          -- PDF 1.7 writer (text, CID fonts, images, links, merging, RC4 encryption, CMS/PKCS#7 signing)
   EggPdf.Cli/          -- CLI tool: eggpdf input.html -o output.pdf
   EggPdf.Service/      -- REST API + WebUI (POST /api/render, GET /e2e, GET /)
   EggPdf.Style/        -- (placeholder for future style resolution module)
@@ -76,8 +76,8 @@ src/
   EggPdf.Fragmentation/ -- (placeholder for future fragmentation)
 
 tests/
-  EggPdf.Tests.Unit/   -- 639 unit tests (parsers, CSS, var/calc, selectors, colors, PDF, PNG, bookmarks, E2E)
-  EggPdf.Tests.Layout/ -- 150 layout tests (block, inline, flex, float, table, grid, margins, lists)
+  EggPdf.Tests.Unit/   -- ~965 unit tests (parsers, CSS, fonts/webfonts, signing, PDF, PNG, E2E render checks)
+  EggPdf.Tests.Layout/ -- ~554 layout tests (block, inline, flex, float, table, grid, margins, lists)
   EggPdf.Tests.E2E/    -- 20 Playwright tests (WebUI, API endpoints)
 
 benchmarks/
@@ -93,7 +93,8 @@ docker/
   Dockerfile.cli       -- CLI Docker image
   docker-compose.yml
 
-docs/                  -- Wiki pages (14 pages, auto-synced to GitHub Wiki)
+site/                  -- GitHub Pages static site (getting-started, fonts, rest-api, ... + llms.txt)
+llms.txt               -- AI/LLM discovery file (repo root)
 ```
 
 ## Test Commands

--- a/README.md
+++ b/README.md
@@ -105,12 +105,13 @@ public class InvoiceService(IRazorToPdfConverter pdf)
 
 ### HTML & CSS
 - Full HTML5 parsing (WHATWG spec-compliant)
-- CSS 2.1 complete + CSS3 (Flexbox, Grid, Multi-column)
+- CSS 2.1 complete + CSS3 (Flexbox with auto margins & baseline alignment, Grid, Multi-column)
 - CSS Custom Properties (`var()`)
 - `@media print` support
-- `@font-face` with WOFF/WOFF2
+- Webfonts: remote `<link>` stylesheets (Google Fonts) and `@font-face` over http(s), data: URIs, or files
 - SVG rendering (vector output, not rasterized)
-- All image formats (JPEG, PNG, GIF, WebP, SVG, Base64)
+- All image formats (JPEG, PNG incl. 1-bit QR codes, GIF, WebP, SVG, Base64)
+- Cloudflare email obfuscation (`data-cfemail`) decoded automatically
 
 ### PDF
 - PDF 1.4 / 1.5 / 1.7 / 2.0
@@ -125,22 +126,18 @@ public class InvoiceService(IRazorToPdfConverter pdf)
 
 ### Typography
 - TrueType/OpenType font embedding with subsetting
-- Font fallback chain
-- CJK support (Chinese, Japanese, Korean)
-- Vietnamese, Thai, Arabic, Hebrew
-- Emoji rendering (color emoji)
+- Weight-accurate faces: `font-weight: 300–900` each select their own variant
+- Font fallback chain + per-codepoint symbol-font fallback (⚠ ✔ …)
+- Full Unicode: Vietnamese and extended Latin out of the box
+- Browser-parity metrics: text measured with the real font, baselines like Chrome
 - Automatic hyphenation
-- Variable font support
 
 ### Business
-- PDF/A (archival: 1b, 2b, 3b)
-- PDF/UA (accessibility)
-- Digital signatures (PAdES)
-- AcroForm fields
-- QR codes and barcodes
-- File attachments (ZUGFeRD/Factur-X e-invoicing)
+- Digital signatures — one-call X.509 signing (`PdfSigner.Sign(pdf, cert)`, detached CMS/PKCS#7) or external-CMS two-step flow for HSMs
+- Password protection with permission flags — view-only PDFs that block editing/copying (RC4 40/128-bit)
+- AcroForm fields (fillable forms from HTML form elements)
 - PDF merging
-- AES-256 encryption
+- QR codes and barcodes
 
 ### Performance
 - Streaming output (constant memory for large documents)

--- a/llms.txt
+++ b/llms.txt
@@ -175,21 +175,53 @@ netstandard2.0, netstandard2.1, net6.0, net8.0, net9.0, net10.0
 ## Key features
 
 - Full HTML5 (WHATWG spec)
-- CSS 2.1 + Flexbox, Grid, Multi-column, Custom Properties
+- CSS 2.1 + Flexbox (incl. auto margins, align-items:baseline), Grid, Multi-column, Custom Properties
 - @media print, @page rules
-- @font-face (WOFF/WOFF2)
+- Webfonts: remote <link> stylesheets (Google Fonts) and @font-face over http(s)/data:/file, weight-accurate faces 300–900
+- Full Unicode text: Vietnamese and extended Latin, per-codepoint symbol-font fallback (⚠ ✔ …)
+- Browser-parity text layout: real font metrics for measurement, baseline placement, letter-spacing, word-break:break-all
 - SVG (vector, not rasterized)
-- All image formats (JPEG, PNG, GIF, WebP, Base64)
+- Image formats: JPEG, PNG (incl. 1/2/4-bit grayscale QR codes), GIF, WebP, BMP, Base64
 - Bookmarks, links, TOC
-- Running headers/footers, page numbers
 - Repeating table headers
 - TrueType/OpenType embedding with subsetting
-- CJK, Arabic, Hebrew, emoji
-- PDF/A (1b, 2b, 3b), PDF/UA, tagged PDF
-- Digital signatures (PAdES)
-- AES-256 encryption
+- Digital signatures: one-call X.509 signing (detached CMS/PKCS#7, adbe.pkcs7.detached) or external-CMS two-step flow
+- Encryption: RC4 40/128-bit with owner/user passwords and permission flags (via REST /api/encrypt)
+- Cloudflare email obfuscation (data-cfemail) decoded automatically
 - PDF merging
-- File attachments (ZUGFeRD/Factur-X)
+
+## Security: signing and encryption
+
+```csharp
+using EggPdf;
+using EggPdf.Pdf;
+using System.Security.Cryptography.X509Certificates;
+
+// One-call PKI signing — embeds a detached CMS/PKCS#7 signature
+// (adbe.pkcs7.detached) with a valid /ByteRange. Zero extra packages.
+byte[] pdf = await HtmlToPdf.RenderAsync(html);
+byte[] signed = PdfSigner.Sign(pdf, x509CertificateWithPrivateKey,
+    new PdfSigner.SignOptions { Name = "Jane Smith", Reason = "Approval", Location = "Hanoi" });
+
+// Two-step flow when the private key lives elsewhere (HSM, signing service):
+byte[] withPlaceholder = PdfSigner.AddSignaturePlaceholder(pdf, options);
+// ... compute CMS bytes externally over the ByteRange content ...
+byte[] done = PdfSigner.SignWithCmsData(withPlaceholder, cmsBytes);
+```
+
+View-only protection (RC4 40/128-bit, owner/user passwords, permission flags —
+printing/copying/modifying) is available through the REST service:
+
+```bash
+curl -X POST http://localhost:8080/api/encrypt \
+  -H "Content-Type: application/json" \
+  -d '{"html":"<h1>Confidential</h1>","ownerPassword":"secret","allowCopying":false,"allowModifying":false}' \
+  -o protected.pdf
+```
+
+Note: PDF permission flags are advisory (enforced by compliant viewers, not
+cryptography). For tamper evidence, prefer digital signatures — any change to
+a signed PDF invalidates the signature.
 
 ## Architecture
 

--- a/site/fonts.html
+++ b/site/fonts.html
@@ -72,10 +72,16 @@
         EggPdf resolves fonts in this order:
       </p>
       <ol>
-        <li><code>@font-face</code> declarations in CSS (loaded from file when <code>basePath</code> is set)</li>
+        <li><code>@font-face</code> declarations in CSS — from <code>http(s)</code> URLs (Google Fonts and other CDNs), <code>data:</code> URIs, or files (relative paths resolve against <code>basePath</code>)</li>
         <li>System-installed TrueType/OpenType fonts matched by name</li>
         <li>Built-in PDF standard fonts: Helvetica, Times, Courier</li>
       </ol>
+      <p>
+        Remote <code>&lt;link rel="stylesheet"&gt;</code> tags are fetched too, so a plain Google Fonts
+        <code>&lt;link&gt;</code> works out of the box — every declared weight (300–900) selects its own
+        face, and codepoints missing from the chosen font (symbols like ⚠) fall back to a system
+        symbol font automatically.
+      </p>
       <p>
         Any matched TrueType font is automatically <strong>subset</strong> — only the glyphs actually used
         in the document are embedded, keeping PDF size small.
@@ -106,6 +112,22 @@
       <p>
         These are the 14 standard PDF fonts defined in the PDF specification. Every PDF viewer renders them
         without needing a font file embedded in the document.
+      </p>
+
+      <h2 id="webfonts">Webfonts — Google Fonts and remote URLs</h2>
+      <p>
+        Reference a hosted stylesheet exactly like on the web — EggPdf fetches the CSS, downloads the
+        declared faces, and embeds subsets with the document's real glyphs (full Unicode, including
+        Vietnamese and other extended Latin):
+      </p>
+      <div class="code-block"><pre><code><span class="pun">&lt;</span><span class="typ">link</span> <span class="kw">href</span><span class="pun">=</span><span class="str">"https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@300;400;600;700;800"</span> <span class="kw">rel</span><span class="pun">=</span><span class="str">"stylesheet"</span><span class="pun">&gt;</span>
+<span class="pun">&lt;</span><span class="typ">style</span><span class="pun">&gt;</span>
+<span class="typ">body</span> <span class="pun">{</span> <span class="kw">font-family</span><span class="pun">:</span> <span class="str">'Be Vietnam Pro', Arial, sans-serif</span><span class="pun">;</span> <span class="pun">}</span>
+<span class="pun">&lt;/</span><span class="typ">style</span><span class="pun">&gt;</span></code></pre></div>
+      <p>
+        Intermediate weights (<code>font-weight: 500/600/800…</code>) embed the matching variant
+        instead of snapping to regular/bold, and text is measured with the real font metrics so line
+        breaks match the browser's.
       </p>
 
       <h2 id="font-face">@font-face — load from file</h2>

--- a/site/index.html
+++ b/site/index.html
@@ -29,7 +29,7 @@
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Windows, Linux, macOS",
     "description": "Pure C#, zero-dependency HTML/CSS-to-PDF rendering engine for .NET. MIT license, Chrome-quality output.",
-    "softwareVersion": "1.0.2",
+    "softwareVersion": "1.4.0",
     "license": "https://opensource.org/licenses/MIT",
     "url": "https://eggspot.github.io/EggPdf/",
     "downloadUrl": "https://www.nuget.org/packages/EggPdf",

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -44,6 +44,19 @@ curl -X POST http://localhost:8080/api/render \
   -d '{"html": "<h1>Hello</h1>"}' -o output.pdf
 ```
 
+## Webfonts & Unicode
+- Google Fonts / remote `<link>` stylesheets fetched automatically; @font-face over http(s), data:, or files
+- Weight-accurate faces (300–900), real font metrics, full Vietnamese/extended Latin, symbol fallback (⚠ ✔)
+
+## Security
+```csharp
+// One-call PKI signing (detached CMS/PKCS#7, zero extra packages)
+byte[] signed = EggPdf.Pdf.PdfSigner.Sign(pdf, x509CertWithPrivateKey,
+    new EggPdf.Pdf.PdfSigner.SignOptions { Name = "Jane", Reason = "Approval" });
+```
+- View-only PDFs via REST `POST /api/encrypt` (RC4 128-bit, owner/user passwords, print/copy/modify flags)
+- Permission flags are advisory; signatures give cryptographic tamper evidence
+
 ## Performance
 - Simple page: 13 µs — Invoice: 86 µs — Large table (100 rows): 1.2 ms
 - Thread-safe, streaming output, zero allocations on hot path

--- a/site/rest-api.html
+++ b/site/rest-api.html
@@ -169,6 +169,32 @@
   <span class="str">"version"</span><span class="pun">:</span> <span class="str">"0.3.0"</span>
 <span class="pun">}</span></code></pre></div>
 
+      <h2 id="post-encrypt">POST /api/encrypt</h2>
+      <p>Render HTML and encrypt the resulting PDF (RC4 128-bit) with owner/user passwords and permission flags. Permissions default to view-and-print without modification. Note: PDF permission flags are advisory — compliant viewers enforce them, but they are not cryptographic protection. For tamper evidence, use signing.</p>
+      <h3>Request</h3>
+      <div class="code-block"><pre><code><span class="pun">{</span>
+  <span class="str">"html"</span><span class="pun">:</span> <span class="str">"&lt;h1&gt;Confidential&lt;/h1&gt;"</span><span class="pun">,</span>
+  <span class="str">"userPassword"</span><span class="pun">:</span> <span class="str">""</span><span class="pun">,</span>            <span class="com">// empty = anyone can open</span>
+  <span class="str">"ownerPassword"</span><span class="pun">:</span> <span class="str">"owner-secret"</span><span class="pun">,</span>
+  <span class="str">"allowPrinting"</span><span class="pun">:</span> <span class="kw">true</span><span class="pun">,</span>
+  <span class="str">"allowCopying"</span><span class="pun">:</span> <span class="kw">false</span><span class="pun">,</span>
+  <span class="str">"allowModifying"</span><span class="pun">:</span> <span class="kw">false</span>
+<span class="pun">}</span></code></pre></div>
+      <h3>Response</h3>
+      <p><code>200 OK</code> with <code>application/pdf</code> body (the encrypted document).</p>
+
+      <h2 id="post-sign">POST /api/sign</h2>
+      <p>Add a digital-signature placeholder (<code>adbe.pkcs7.detached</code>) to an existing PDF. The endpoint does not hold private keys: compute the CMS signature with your certificate and embed it via the library (<code>PdfSigner.SignWithCmsData</code>), or sign fully in-process with <code>PdfSigner.Sign(pdfBytes, x509Certificate)</code> when you control the key material.</p>
+      <h3>Request</h3>
+      <div class="code-block"><pre><code><span class="pun">{</span>
+  <span class="str">"pdf"</span><span class="pun">:</span> <span class="str">"&lt;base64-encoded PDF&gt;"</span><span class="pun">,</span>
+  <span class="str">"name"</span><span class="pun">:</span> <span class="str">"Jane Smith"</span><span class="pun">,</span>
+  <span class="str">"reason"</span><span class="pun">:</span> <span class="str">"Approval"</span><span class="pun">,</span>
+  <span class="str">"location"</span><span class="pun">:</span> <span class="str">"Hanoi"</span>
+<span class="pun">}</span></code></pre></div>
+      <h3>Response</h3>
+      <p><code>200 OK</code> with <code>application/pdf</code> body containing the signature placeholder.</p>
+
       <h2 id="curl-examples">curl Examples</h2>
 
       <h3>Minimal — save to file</h3>

--- a/src/EggPdf.Css/BasicStyleResolver.cs
+++ b/src/EggPdf.Css/BasicStyleResolver.cs
@@ -19,6 +19,7 @@ public class BasicStyleResolver
         "font-variant-ligatures", "font-variant-alternates",
         "line-height", "text-align", "text-indent", "text-transform",
         "letter-spacing", "word-spacing", "white-space", "direction",
+        "word-break", "overflow-wrap", "word-wrap", "hyphens",
         "visibility", "list-style-type", "list-style-position",
         "border-collapse", "border-spacing", "caption-side", "empty-cells",
         "quotes", "tab-size",

--- a/src/EggPdf.Css/Cascade/CascadeResolver.cs
+++ b/src/EggPdf.Css/Cascade/CascadeResolver.cs
@@ -287,6 +287,10 @@ public class CascadeResolver
             case "white-space":
             case "letter-spacing":
             case "word-spacing":
+            case "word-break":
+            case "overflow-wrap":
+            case "word-wrap":
+            case "hyphens":
             case "visibility":
             case "text-transform":
             case "direction":
@@ -414,6 +418,7 @@ public class CascadeResolver
         "font-variant-ligatures", "font-variant-alternates",
         "line-height", "text-align", "text-indent", "text-transform",
         "letter-spacing", "word-spacing", "white-space", "direction",
+        "word-break", "overflow-wrap", "word-wrap", "hyphens",
         "visibility", "list-style-type", "list-style-position",
         "border-collapse", "border-spacing", "caption-side", "empty-cells",
         "quotes", "tab-size",

--- a/src/EggPdf.Html/HtmlTokenizer.cs
+++ b/src/EggPdf.Html/HtmlTokenizer.cs
@@ -519,26 +519,136 @@ public class HtmlTokenizer
 
     private string ConsumeNamedReference()
     {
-        // Try common named entities (performance: check most common first)
-        string?[] entities = { "amp", "lt", "gt", "quot", "apos", "nbsp" };
-        string?[] values = { "&", "<", ">", "\"", "'", "\u00A0" };
+        // Scan the maximal alphanumeric run after '&' (entity names are short)
+        int nameEnd = _pos;
+        int maxEnd = Math.Min(_input.Length, _pos + 32);
+        while (nameEnd < maxEnd && IsAsciiAlphanumeric(_input[nameEnd]))
+            nameEnd++;
 
-        for (int i = 0; i < entities.Length; i++)
+        if (nameEnd > _pos && nameEnd < _input.Length && _input[nameEnd] == ';')
         {
-            var name = entities[i]!;
+            var name = _input.Substring(_pos, nameEnd - _pos);
+            if (NamedEntities.TryGetValue(name, out var value))
+            {
+                _pos = nameEnd + 1; // consume name and ';'
+                return value;
+            }
+        }
+
+        // Legacy semicolon-less forms (only the historically supported set)
+        for (int i = 0; i < LegacyEntities.Length; i++)
+        {
+            var name = LegacyEntities[i];
             if (_pos + name.Length <= _input.Length &&
                 string.Compare(_input, _pos, name, 0, name.Length, StringComparison.Ordinal) == 0)
             {
                 _pos += name.Length;
                 if (_pos < _input.Length && _input[_pos] == ';')
                     _pos++;
-                return values[i]!;
+                return LegacyValues[i];
             }
         }
 
         // Unknown entity: emit '&' and continue
         return "&";
     }
+
+    private static bool IsAsciiAlphanumeric(char c) =>
+        (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+
+    // Entities that historically worked without a trailing semicolon
+    private static readonly string[] LegacyEntities = { "amp", "lt", "gt", "quot", "apos", "nbsp" };
+    private static readonly string[] LegacyValues = { "&", "<", ">", "\"", "'", "\u00A0" };
+
+    /// <summary>Common HTML named character references (WHATWG subset, case-sensitive).</summary>
+    private static readonly Dictionary<string, string> NamedEntities = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        // Core
+        ["amp"] = "&", ["lt"] = "<", ["gt"] = ">", ["quot"] = "\"", ["apos"] = "'",
+        // Spaces and dashes
+        ["nbsp"] = "\u00A0", ["ensp"] = "\u2002", ["emsp"] = "\u2003", ["thinsp"] = "\u2009",
+        ["shy"] = "\u00AD", ["ndash"] = "\u2013", ["mdash"] = "\u2014", ["horbar"] = "\u2015",
+        // Quotes
+        ["lsquo"] = "\u2018", ["rsquo"] = "\u2019", ["sbquo"] = "\u201A",
+        ["ldquo"] = "\u201C", ["rdquo"] = "\u201D", ["bdquo"] = "\u201E",
+        ["lsaquo"] = "\u2039", ["rsaquo"] = "\u203A", ["laquo"] = "\u00AB", ["raquo"] = "\u00BB",
+        ["prime"] = "\u2032", ["Prime"] = "\u2033",
+        // Punctuation and symbols
+        ["hellip"] = "\u2026", ["middot"] = "\u00B7", ["bull"] = "\u2022",
+        ["dagger"] = "\u2020", ["Dagger"] = "\u2021", ["permil"] = "\u2030",
+        ["sect"] = "\u00A7", ["para"] = "\u00B6", ["iexcl"] = "\u00A1", ["iquest"] = "\u00BF",
+        ["brvbar"] = "\u00A6", ["uml"] = "\u00A8", ["macr"] = "\u00AF", ["acute"] = "\u00B4",
+        ["cedil"] = "\u00B8", ["ordf"] = "\u00AA", ["ordm"] = "\u00BA",
+        ["copy"] = "\u00A9", ["reg"] = "\u00AE", ["trade"] = "\u2122",
+        ["deg"] = "\u00B0", ["plusmn"] = "\u00B1", ["micro"] = "\u00B5",
+        ["sup1"] = "\u00B9", ["sup2"] = "\u00B2", ["sup3"] = "\u00B3",
+        ["frac14"] = "\u00BC", ["frac12"] = "\u00BD", ["frac34"] = "\u00BE",
+        ["times"] = "\u00D7", ["divide"] = "\u00F7", ["minus"] = "\u2212",
+        ["lowast"] = "\u2217", ["frasl"] = "\u2044",
+        // Currency
+        ["euro"] = "\u20AC", ["pound"] = "\u00A3", ["yen"] = "\u00A5",
+        ["cent"] = "\u00A2", ["curren"] = "\u00A4",
+        // Latin-1 letters (uppercase)
+        ["Agrave"] = "\u00C0", ["Aacute"] = "\u00C1", ["Acirc"] = "\u00C2", ["Atilde"] = "\u00C3",
+        ["Auml"] = "\u00C4", ["Aring"] = "\u00C5", ["AElig"] = "\u00C6", ["Ccedil"] = "\u00C7",
+        ["Egrave"] = "\u00C8", ["Eacute"] = "\u00C9", ["Ecirc"] = "\u00CA", ["Euml"] = "\u00CB",
+        ["Igrave"] = "\u00CC", ["Iacute"] = "\u00CD", ["Icirc"] = "\u00CE", ["Iuml"] = "\u00CF",
+        ["ETH"] = "\u00D0", ["Ntilde"] = "\u00D1",
+        ["Ograve"] = "\u00D2", ["Oacute"] = "\u00D3", ["Ocirc"] = "\u00D4", ["Otilde"] = "\u00D5",
+        ["Ouml"] = "\u00D6", ["Oslash"] = "\u00D8",
+        ["Ugrave"] = "\u00D9", ["Uacute"] = "\u00DA", ["Ucirc"] = "\u00DB", ["Uuml"] = "\u00DC",
+        ["Yacute"] = "\u00DD", ["THORN"] = "\u00DE",
+        // Latin-1 letters (lowercase)
+        ["szlig"] = "\u00DF",
+        ["agrave"] = "\u00E0", ["aacute"] = "\u00E1", ["acirc"] = "\u00E2", ["atilde"] = "\u00E3",
+        ["auml"] = "\u00E4", ["aring"] = "\u00E5", ["aelig"] = "\u00E6", ["ccedil"] = "\u00E7",
+        ["egrave"] = "\u00E8", ["eacute"] = "\u00E9", ["ecirc"] = "\u00EA", ["euml"] = "\u00EB",
+        ["igrave"] = "\u00EC", ["iacute"] = "\u00ED", ["icirc"] = "\u00EE", ["iuml"] = "\u00EF",
+        ["eth"] = "\u00F0", ["ntilde"] = "\u00F1",
+        ["ograve"] = "\u00F2", ["oacute"] = "\u00F3", ["ocirc"] = "\u00F4", ["otilde"] = "\u00F5",
+        ["ouml"] = "\u00F6", ["oslash"] = "\u00F8",
+        ["ugrave"] = "\u00F9", ["uacute"] = "\u00FA", ["ucirc"] = "\u00FB", ["uuml"] = "\u00FC",
+        ["yacute"] = "\u00FD", ["thorn"] = "\u00FE", ["yuml"] = "\u00FF",
+        // Ligatures and accents
+        ["OElig"] = "\u0152", ["oelig"] = "\u0153", ["Scaron"] = "\u0160", ["scaron"] = "\u0161",
+        ["Yuml"] = "\u0178", ["fnof"] = "\u0192", ["circ"] = "\u02C6", ["tilde"] = "\u02DC",
+        // Arrows
+        ["larr"] = "\u2190", ["uarr"] = "\u2191", ["rarr"] = "\u2192", ["darr"] = "\u2193",
+        ["harr"] = "\u2194", ["crarr"] = "\u21B5",
+        ["lArr"] = "\u21D0", ["uArr"] = "\u21D1", ["rArr"] = "\u21D2", ["dArr"] = "\u21D3", ["hArr"] = "\u21D4",
+        // Math
+        ["infin"] = "\u221E", ["ne"] = "\u2260", ["equiv"] = "\u2261", ["le"] = "\u2264", ["ge"] = "\u2265",
+        ["sum"] = "\u2211", ["prod"] = "\u220F", ["int"] = "\u222B", ["radic"] = "\u221A",
+        ["asymp"] = "\u2248", ["prop"] = "\u221D", ["part"] = "\u2202", ["nabla"] = "\u2207",
+        ["forall"] = "\u2200", ["exist"] = "\u2203", ["empty"] = "\u2205",
+        ["isin"] = "\u2208", ["notin"] = "\u2209", ["ni"] = "\u220B",
+        ["cap"] = "\u2229", ["cup"] = "\u222A", ["sub"] = "\u2282", ["sup"] = "\u2283",
+        ["sube"] = "\u2286", ["supe"] = "\u2287", ["oplus"] = "\u2295", ["otimes"] = "\u2297",
+        ["perp"] = "\u22A5", ["sdot"] = "\u22C5", ["not"] = "\u00AC", ["and"] = "\u2227", ["or"] = "\u2228",
+        ["ang"] = "\u2220", ["there4"] = "\u2234", ["sim"] = "\u223C", ["cong"] = "\u2245",
+        // Greek (uppercase)
+        ["Alpha"] = "\u0391", ["Beta"] = "\u0392", ["Gamma"] = "\u0393", ["Delta"] = "\u0394",
+        ["Epsilon"] = "\u0395", ["Zeta"] = "\u0396", ["Eta"] = "\u0397", ["Theta"] = "\u0398",
+        ["Iota"] = "\u0399", ["Kappa"] = "\u039A", ["Lambda"] = "\u039B", ["Mu"] = "\u039C",
+        ["Nu"] = "\u039D", ["Xi"] = "\u039E", ["Omicron"] = "\u039F", ["Pi"] = "\u03A0",
+        ["Rho"] = "\u03A1", ["Sigma"] = "\u03A3", ["Tau"] = "\u03A4", ["Upsilon"] = "\u03A5",
+        ["Phi"] = "\u03A6", ["Chi"] = "\u03A7", ["Psi"] = "\u03A8", ["Omega"] = "\u03A9",
+        // Greek (lowercase)
+        ["alpha"] = "\u03B1", ["beta"] = "\u03B2", ["gamma"] = "\u03B3", ["delta"] = "\u03B4",
+        ["epsilon"] = "\u03B5", ["zeta"] = "\u03B6", ["eta"] = "\u03B7", ["theta"] = "\u03B8",
+        ["iota"] = "\u03B9", ["kappa"] = "\u03BA", ["lambda"] = "\u03BB", ["mu"] = "\u03BC",
+        ["nu"] = "\u03BD", ["xi"] = "\u03BE", ["omicron"] = "\u03BF", ["pi"] = "\u03C0",
+        ["rho"] = "\u03C1", ["sigmaf"] = "\u03C2", ["sigma"] = "\u03C3", ["tau"] = "\u03C4",
+        ["upsilon"] = "\u03C5", ["phi"] = "\u03C6", ["chi"] = "\u03C7", ["psi"] = "\u03C8",
+        ["omega"] = "\u03C9",
+        // Misc symbols
+        ["spades"] = "\u2660", ["clubs"] = "\u2663", ["hearts"] = "\u2665", ["diams"] = "\u2666",
+        ["loz"] = "\u25CA", ["oline"] = "\u203E", ["alefsym"] = "\u2135",
+        ["weierp"] = "\u2118", ["image"] = "\u2111", ["real"] = "\u211C",
+        ["zwnj"] = "\u200C", ["zwj"] = "\u200D", ["lrm"] = "\u200E", ["rlm"] = "\u200F",
+        ["ceil"] = "\u2308", ["rceil"] = "\u2309", ["lceil"] = "\u2308",
+        ["lfloor"] = "\u230A", ["rfloor"] = "\u230B", ["lang"] = "\u2329", ["rang"] = "\u232A",
+    };
 
     private static bool IsHexDigit(char c) =>
         (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');

--- a/src/EggPdf.Layout/BlockLayout.cs
+++ b/src/EggPdf.Layout/BlockLayout.cs
@@ -2486,6 +2486,11 @@ public static class BlockLayout
             bool runBreakWord = runOverflowWrap == "break-word" || runOverflowWrap == "anywhere" ||
                                 runWordBreak == "break-all" || runWordBreak == "break-word";
 
+            // vertical-align: baseline (default) — smaller runs sit on the parent
+            // line's baseline, not the line top (ascent approximated at 0.8em)
+            float baselineShift = run.FontSize < parentFontSize
+                ? (parentFontSize - run.FontSize) * 0.8f : 0f;
+
             // Iterate words inline — avoids allocating a string[] upfront.
             int wPos = 0;
             bool firstWord = true;
@@ -2539,7 +2544,7 @@ public static class BlockLayout
                             Element = (!elementAssigned && wrapperElement != null) ? wrapperElement : null,
                             Style = run.Style,
                             X = box.X + box.PaddingLeft + inlineX,
-                            Y = box.Y + box.PaddingTop + childY,
+                            Y = box.Y + box.PaddingTop + childY + baselineShift,
                             Width = chunkWidth,
                             Height = lhRun,
                             ContentWidth = chunkWidth,
@@ -2570,7 +2575,7 @@ public static class BlockLayout
                     Element = (!elementAssigned && wrapperElement != null) ? wrapperElement : null,
                     Style = run.Style,
                     X = box.X + box.PaddingLeft + inlineX,
-                    Y = box.Y + box.PaddingTop + childY,
+                    Y = box.Y + box.PaddingTop + childY + baselineShift,
                     Width = wordWidth,
                     Height = lhRun,
                     ContentWidth = wordWidth,

--- a/src/EggPdf.Layout/BlockLayout.cs
+++ b/src/EggPdf.Layout/BlockLayout.cs
@@ -1439,11 +1439,16 @@ public static class BlockLayout
                 // Absolute: relative to nearest positioned ancestor or this box if positioned
                 if (position == "relative" || position == "absolute" || position == "fixed" || position == "sticky")
                 {
-                    // This box is the containing block
-                    cbX = box.X;
-                    cbY = box.Y;
-                    cbWidth = box.Width;
-                    cbHeight = box.Height;
+                    // This box is the containing block — its PADDING box (CSS 2.1
+                    // §10.1), so offsets count from inside the border.
+                    float cbBorderLeft = ResolveLength(style.Get("border-left-width"), 0, fontSize);
+                    float cbBorderRight = ResolveLength(style.Get("border-right-width"), 0, fontSize);
+                    float cbBorderTop = ResolveLength(style.Get("border-top-width"), 0, fontSize);
+                    float cbBorderBottom = ResolveLength(style.Get("border-bottom-width"), 0, fontSize);
+                    cbX = box.X + cbBorderLeft;
+                    cbY = box.Y + cbBorderTop;
+                    cbWidth = box.Width - cbBorderLeft - cbBorderRight;
+                    cbHeight = box.Height - cbBorderTop - cbBorderBottom;
                 }
                 else
                 {

--- a/src/EggPdf.Layout/BlockLayout.cs
+++ b/src/EggPdf.Layout/BlockLayout.cs
@@ -783,16 +783,21 @@ public static class BlockLayout
                     var ilFontFamily = style.FontFamily;
                     var ilFontWeight = style.FontWeight;
                     var ilFontStyle = style.Get("font-style");
+                    float ilLetterSpacing = ResolveLength(style.Get("letter-spacing"), 0, fontSize);
                     float ilLineHeight = TextMeasurer.GetLineHeight(fontSize, style.Get("line-height"));
                     var ilTextData = TrimHtmlText(textNode.Data);
                     if (string.IsNullOrEmpty(ilTextData)) continue;
+
+                    // Measure the transformed text (uppercase is wider); paint-time
+                    // transform is idempotent so the box text may carry it too.
+                    ilTextData = ApplyTextTransformForMeasure(ilTextData, style);
 
                     // Split into words and lay them out inline
                     var words = ilTextData.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                     foreach (var word in words)
                     {
                         var wordWithSpace = (inlineX > 0 ? " " : "") + word;
-                        float wordWidth = TextMeasurer.MeasureWidth(wordWithSpace, fontSize, ilFontFamily, ilFontWeight, ilFontStyle);
+                        float wordWidth = TextMeasurer.MeasureWidth(wordWithSpace, fontSize, ilFontFamily, ilFontWeight, ilFontStyle, ilLetterSpacing);
 
                         // Wrap to next line if word doesn't fit
                         if (inlineX > 0 && inlineX + wordWidth > childContainingWidth)
@@ -801,7 +806,7 @@ public static class BlockLayout
                             inlineX = 0;
                             inlineLineHeight = 0;
                             wordWithSpace = word;
-                            wordWidth = TextMeasurer.MeasureWidth(word, fontSize, ilFontFamily, ilFontWeight, ilFontStyle);
+                            wordWidth = TextMeasurer.MeasureWidth(word, fontSize, ilFontFamily, ilFontWeight, ilFontStyle, ilLetterSpacing);
                         }
 
                         var textBox = new LayoutBox
@@ -852,6 +857,11 @@ public static class BlockLayout
                 bool breakWord = overflowWrap == "break-word" || overflowWrap == "anywhere" ||
                                  wordBreak == "break-all" || wordBreak == "break-word";
                 bool enableHyphenation = style.Get("hyphens") == "auto";
+                float blockLetterSpacing = ResolveLength(style.Get("letter-spacing"), 0, fontSize);
+
+                // Wrap and measure the transformed text (uppercase is wider); the
+                // paint-time transform is idempotent, so storing it in the box is safe.
+                textData = ApplyTextTransformForMeasure(textData, style);
 
                 // text-wrap: balance — compute an optimal balanced width before wrapping
                 float balanceWidth = childContainingWidth;
@@ -869,7 +879,7 @@ public static class BlockLayout
                 // For text-indent, reduce first line's available width
                 float firstLineWidth = textIndent > 0 ? balanceWidth - textIndent : balanceWidth;
                 var lines = TextMeasurer.WrapText(textData, fontSize, fontFamily, fontWeight, fontStyle,
-                    firstLineWidth > 0 ? firstLineWidth : balanceWidth, whiteSpaceProp, breakWord, enableHyphenation);
+                    firstLineWidth > 0 ? firstLineWidth : balanceWidth, whiteSpaceProp, breakWord, enableHyphenation, blockLetterSpacing);
 
                 // If indent caused wrapping and there are remaining lines, re-wrap with full width
                 if (textIndent > 0 && lines.Count > 1)
@@ -879,7 +889,7 @@ public static class BlockLayout
                     lines = new System.Collections.Generic.List<string> { firstLine };
                     if (!string.IsNullOrEmpty(remaining))
                     {
-                        var moreLines = TextMeasurer.WrapText(remaining, fontSize, fontFamily, fontWeight, fontStyle, childContainingWidth, whiteSpaceProp, breakWord, enableHyphenation);
+                        var moreLines = TextMeasurer.WrapText(remaining, fontSize, fontFamily, fontWeight, fontStyle, childContainingWidth, whiteSpaceProp, breakWord, enableHyphenation, blockLetterSpacing);
                         lines.AddRange(moreLines);
                     }
                 }
@@ -1025,7 +1035,7 @@ public static class BlockLayout
                             Y = box.Y + box.PaddingTop + childY,
                             Width = childContainingWidth,
                             Height = lineHeight,
-                            ContentWidth = TextMeasurer.MeasureWidth(line, fontSize, fontFamily, fontWeight, fontStyle),
+                            ContentWidth = TextMeasurer.MeasureWidth(line, fontSize, fontFamily, fontWeight, fontStyle, blockLetterSpacing),
                             ContentHeight = lineHeight,
                             Text = line
                         };
@@ -1308,6 +1318,20 @@ public static class BlockLayout
         }
 
         return box;
+    }
+
+    /// <summary>
+    /// Apply text-transform for width measurement (uppercase glyphs are wider).
+    /// The painted text is transformed by the renderer; measuring the transformed
+    /// text keeps layout and paint in agreement. Box text stays untransformed.
+    /// </summary>
+    private static string ApplyTextTransformForMeasure(string text, ComputedStyle style)
+    {
+        var tt = style.Get("text-transform");
+        if (string.IsNullOrEmpty(tt) || tt == "none") return text;
+        if (tt == "uppercase") return text.ToUpperInvariant();
+        if (tt == "lowercase") return text.ToLowerInvariant();
+        return text; // capitalize changes width negligibly
     }
 
     /// <summary>Walk up parent chain to find page height.</summary>
@@ -2447,9 +2471,14 @@ public static class BlockLayout
 
             if (string.IsNullOrEmpty(text)) continue;
 
+            // Measure the transformed text (uppercase is wider); the paint-time
+            // transform is idempotent so word boxes may carry it too.
+            text = ApplyTextTransformForMeasure(text, run.Style);
+
             var fontFamily = run.Style.FontFamily;
             var fontWeight = run.Style.FontWeight;
             var fontStyle = run.Style.Get("font-style");
+            float runLetterSpacing = ResolveLength(run.Style.Get("letter-spacing"), 0, run.FontSize);
             float lhRun = TextMeasurer.GetLineHeight(run.FontSize, run.Style.Get("line-height"));
 
             // Iterate words inline — avoids allocating a string[] upfront.
@@ -2469,7 +2498,7 @@ public static class BlockLayout
                 // text run, not the strong run).
                 bool needSpace = inlineX > 0 && (!firstWord || run.HasLeadingSpace || prevRunTrailingSpace);
                 var wordText = needSpace ? " " + word : word;
-                float wordWidth = TextMeasurer.MeasureWidth(wordText, run.FontSize, fontFamily, fontWeight, fontStyle);
+                float wordWidth = TextMeasurer.MeasureWidth(wordText, run.FontSize, fontFamily, fontWeight, fontStyle, runLetterSpacing);
 
                 // Wrap to next line if doesn't fit
                 if (inlineX > 0 && inlineX + wordWidth > containerWidth)
@@ -2478,7 +2507,7 @@ public static class BlockLayout
                     inlineX = 0;
                     inlineLineHeight = 0;
                     wordText = word; // no space prefix after wrap
-                    wordWidth = TextMeasurer.MeasureWidth(wordText, run.FontSize, fontFamily, fontWeight, fontStyle);
+                    wordWidth = TextMeasurer.MeasureWidth(wordText, run.FontSize, fontFamily, fontWeight, fontStyle, runLetterSpacing);
                 }
 
                 var textBox = new LayoutBox

--- a/src/EggPdf.Layout/BlockLayout.cs
+++ b/src/EggPdf.Layout/BlockLayout.cs
@@ -273,6 +273,12 @@ public static class BlockLayout
                 box.Y += offsetTopFlex;
             }
 
+            // Absolutely positioned children are out-of-flow (excluded from flex
+            // items); place them now that the container's final size is known.
+            var flexAbsChildren = CollectAbsoluteChildren(element, style, resolver);
+            if (flexAbsChildren.Count > 0)
+                LayoutAbsoluteChildren(flexAbsChildren, box, position, containingWidth, parent, fontSize, resolver, style);
+
             return box;
         }
 
@@ -326,6 +332,12 @@ public static class BlockLayout
                 float offsetTopGrid = ResolveLength(style.Get("top"), 0, fontSize);
                 box.Y += offsetTopGrid;
             }
+
+            // Absolutely positioned children are out-of-flow (excluded from grid
+            // items); place them now that the container's final size is known.
+            var gridAbsChildren = CollectAbsoluteChildren(element, style, resolver);
+            if (gridAbsChildren.Count > 0)
+                LayoutAbsoluteChildren(gridAbsChildren, box, position, containingWidth, parent, fontSize, resolver, style);
 
             return box;
         }
@@ -405,6 +417,10 @@ public static class BlockLayout
         // Form element special rendering: inject value/content text for void/custom form elements
         childY = InjectFormElementContent(element, style, box, fontSize, childContainingWidth, childY);
 
+        // Tracks a collapsed boundary space owned by the preceding text node
+        // ("Căn cứ <strong>Luật</strong>": the space precedes the inline element).
+        bool prevTextEndedWithSpace = false;
+
         foreach (var childNode in element.ChildNodes)
         {
             if (childNode is HtmlElement childElem)
@@ -422,7 +438,11 @@ public static class BlockLayout
                     continue;
                 }
 
-                if (IsBlockLevel(childStyle.Display))
+                // Images must keep their dedicated branch even when display:block
+                // (the generic block path would lose ImageSource entirely).
+                bool isImageElement = childElem.TagName == "img" || childElem.TagName == "picture";
+
+                if (IsBlockLevel(childStyle.Display) && !isImageElement)
                 {
                     // Flush any pending inline content
                     if (inlineX > 0)
@@ -606,8 +626,11 @@ public static class BlockLayout
                     float imgWidth = ResolveImgDimension(childStyle.Width, childElem.GetAttribute("width"), childContainingWidth, fontSize, 150);
                     float imgHeight = ResolveImgDimension(childStyle.Height, childElem.GetAttribute("height"), 0, fontSize, 150);
 
+                    // display:block images occupy their own line
+                    bool imgIsBlock = IsBlockLevel(childStyle.Display);
+
                     // Check if image fits on current inline line
-                    if (inlineX > 0 && inlineX + imgWidth > childContainingWidth)
+                    if (inlineX > 0 && (imgIsBlock || inlineX + imgWidth > childContainingWidth))
                     {
                         childY += inlineLineHeight;
                         inlineX = 0;
@@ -631,9 +654,20 @@ public static class BlockLayout
                         ImageSource = imgSrc
                     };
                     box.Children.Add(childBox);
-                    inlineX += imgWidth;
-                    if (imgHeight > inlineLineHeight)
-                        inlineLineHeight = imgHeight;
+
+                    if (imgIsBlock)
+                    {
+                        childY += imgHeight;
+                        inlineX = 0;
+                        inlineLineHeight = 0;
+                        hasBlockChild = true;
+                    }
+                    else
+                    {
+                        inlineX += imgWidth;
+                        if (imgHeight > inlineLineHeight)
+                            inlineLineHeight = imgHeight;
+                    }
                 }
                 else if (childElem.TagName == "picture")
                 {
@@ -681,8 +715,13 @@ public static class BlockLayout
                         inlineX = 0;
                         inlineLineHeight = 0;
                     }
-                    childBox.X = box.X + box.PaddingLeft + inlineX;
+                    // X is absolute (shift descendants); Y is parent-relative and
+                    // resolved in the post-layout pass.
+                    float ibDeltaX = box.X + box.PaddingLeft + inlineX - childBox.X;
+                    childBox.X += ibDeltaX;
                     childBox.Y = box.Y + box.PaddingTop + childY;
+                    if (Math.Abs(ibDeltaX) > 0.01f)
+                        FlexLayout.OffsetChildren(childBox, ibDeltaX, 0);
                     box.Children.Add(childBox);
                     inlineX += ibWidth;
                     if (childBox.Height > inlineLineHeight) inlineLineHeight = childBox.Height;
@@ -698,6 +737,13 @@ public static class BlockLayout
                     // Inline elements: collect text runs with style info and lay out word-by-word
                     var runs = new System.Collections.Generic.List<InlineRun>();
                     CollectInlineRuns(childElem, childStyle, ResolveFontSize(childStyle.FontSize, fontSize), resolver, runs);
+                    if (runs.Count > 0 && prevTextEndedWithSpace)
+                    {
+                        var firstRun = runs[0];
+                        firstRun.HasLeadingSpace = true;
+                        runs[0] = firstRun;
+                    }
+                    prevTextEndedWithSpace = false;
                     if (runs.Count > 0)
                     {
                         LayoutInlineRuns(runs, box, childElem, ref inlineX, ref childY, ref inlineLineHeight,
@@ -774,6 +820,9 @@ public static class BlockLayout
                         if (ilLineHeight > inlineLineHeight)
                             inlineLineHeight = ilLineHeight;
                     }
+
+                    prevTextEndedWithSpace = textNode.Data.Length > 0 &&
+                        char.IsWhiteSpace(textNode.Data[textNode.Data.Length - 1]);
                     continue;
                 }
 
@@ -1249,6 +1298,60 @@ public static class BlockLayout
             box.Height = maxHeight.Value;
 
         // Layout absolutely/fixed positioned children (deferred from normal flow)
+        LayoutAbsoluteChildren(absChildren, box, position, containingWidth, parent, fontSize, resolver, style);
+
+        // Apply relative/sticky position Y offset (sticky behaves like relative in PDF — no scrolling)
+        if (position == "relative" || position == "sticky")
+        {
+            float offsetTop = ResolveLength(style.Get("top"), 0, fontSize);
+            box.Y += offsetTop;
+        }
+
+        return box;
+    }
+
+    /// <summary>Walk up parent chain to find page height.</summary>
+    private static float FindPageHeight(LayoutBox parent)
+    {
+        // The root box has Height set to page height and no Element
+        if (parent.Element == null && parent.Height > 0)
+            return parent.Height;
+        // Default A4 page height in CSS px
+        return parent.Height > 0 ? parent.Height : 841.89f;
+    }
+
+    /// <summary>
+    /// Collect absolutely/fixed positioned element children (out-of-flow).
+    /// Used by flex and grid containers, whose item collectors skip them.
+    /// </summary>
+    private static System.Collections.Generic.List<(HtmlElement elem, ComputedStyle style, string pos)> CollectAbsoluteChildren(
+        HtmlElement element, ComputedStyle style, Func<HtmlElement, ComputedStyle?, ComputedStyle> resolver)
+    {
+        var result = new System.Collections.Generic.List<(HtmlElement elem, ComputedStyle style, string pos)>();
+        foreach (var childNode in element.ChildNodes)
+        {
+            if (!(childNode is HtmlElement childElem))
+                continue;
+            var childStyle = resolver(childElem, style);
+            if (childStyle.Display == "none")
+                continue;
+            var childPosition = childStyle.Get("position");
+            if (childPosition == "absolute" || childPosition == "fixed")
+                result.Add((childElem, childStyle, childPosition!));
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Position absolutely/fixed positioned children relative to their containing
+    /// block (this box when positioned, else the page root). Must run after the
+    /// container's final size is known. Appends the boxes to box.Children.
+    /// </summary>
+    private static void LayoutAbsoluteChildren(
+        System.Collections.Generic.List<(HtmlElement elem, ComputedStyle style, string pos)> absChildren,
+        LayoutBox box, string? position, float containingWidth, LayoutBox parent, float fontSize,
+        Func<HtmlElement, ComputedStyle?, ComputedStyle> resolver, ComputedStyle style)
+    {
         for (int ai = 0; ai < absChildren.Count; ai++)
         {
             var absEntry = absChildren[ai];
@@ -1324,43 +1427,34 @@ public static class BlockLayout
                 }
             }
 
-            // Position X
+            // Position X: offsets move the box AND its already-laid-out descendants
+            float targetX;
             if (leftVal.HasValue)
-                absBox.X = cbX + leftVal.Value + absBox.MarginLeft;
+                targetX = cbX + leftVal.Value + absBox.MarginLeft;
             else if (rightVal.HasValue)
-                absBox.X = cbX + cbWidth - rightVal.Value - absBox.Width - absBox.MarginRight;
+                targetX = cbX + cbWidth - rightVal.Value - absBox.Width - absBox.MarginRight;
             else
-                absBox.X = cbX + absBox.MarginLeft; // default: top-left of containing block
+                targetX = cbX + absBox.MarginLeft; // default: top-left of containing block
 
             // Position Y
+            float targetY;
             if (topVal.HasValue)
-                absBox.Y = cbY + topVal.Value + absBox.MarginTop;
+                targetY = cbY + topVal.Value + absBox.MarginTop;
             else if (bottomVal.HasValue)
-                absBox.Y = cbY + cbHeight - bottomVal.Value - absBox.Height - absBox.MarginBottom;
+                targetY = cbY + cbHeight - bottomVal.Value - absBox.Height - absBox.MarginBottom;
             else
-                absBox.Y = cbY + absBox.MarginTop; // default: top-left of containing block
+                targetY = cbY + absBox.MarginTop; // default: top-left of containing block
+
+            // X is absolute (shift descendants); Y is parent-relative and resolved
+            // in the post-layout pass.
+            float absDeltaX = targetX - absBox.X;
+            absBox.X = targetX;
+            absBox.Y = targetY;
+            if (Math.Abs(absDeltaX) > 0.01f)
+                FlexLayout.OffsetChildren(absBox, absDeltaX, 0);
 
             box.Children.Add(absBox);
         }
-
-        // Apply relative/sticky position Y offset (sticky behaves like relative in PDF — no scrolling)
-        if (position == "relative" || position == "sticky")
-        {
-            float offsetTop = ResolveLength(style.Get("top"), 0, fontSize);
-            box.Y += offsetTop;
-        }
-
-        return box;
-    }
-
-    /// <summary>Walk up parent chain to find page height.</summary>
-    private static float FindPageHeight(LayoutBox parent)
-    {
-        // The root box has Height set to page height and no Element
-        if (parent.Element == null && parent.Height > 0)
-            return parent.Height;
-        // Default A4 page height in CSS px
-        return parent.Height > 0 ? parent.Height : 841.89f;
     }
 
     private static bool IsTableRow(string display)
@@ -2321,6 +2415,7 @@ public static class BlockLayout
         ComputedStyle parentStyle, float parentFontSize)
     {
         bool elementAssigned = false;
+        bool prevRunTrailingSpace = false;
 
         for (int ri = 0; ri < runs.Count; ri++)
         {
@@ -2339,6 +2434,7 @@ public static class BlockLayout
                 {
                     childY += lh;
                 }
+                prevRunTrailingSpace = false;
                 continue;
             }
 
@@ -2368,7 +2464,10 @@ public static class BlockLayout
                 string word = text.Substring(wPos, wEnd - wPos);
                 wPos = wEnd;
 
-                bool needSpace = inlineX > 0 && (!firstWord || run.HasLeadingSpace);
+                // A boundary space also comes from the PREVIOUS run's trailing
+                // whitespace ("đến <strong>bản</strong>": the space belongs to the
+                // text run, not the strong run).
+                bool needSpace = inlineX > 0 && (!firstWord || run.HasLeadingSpace || prevRunTrailingSpace);
                 var wordText = needSpace ? " " + word : word;
                 float wordWidth = TextMeasurer.MeasureWidth(wordText, run.FontSize, fontFamily, fontWeight, fontStyle);
 
@@ -2404,6 +2503,9 @@ public static class BlockLayout
                     inlineLineHeight = lhRun;
                 firstWord = false;
             }
+
+            prevRunTrailingSpace = run.Text.Length > 0 &&
+                char.IsWhiteSpace(run.Text[run.Text.Length - 1]);
         }
     }
 

--- a/src/EggPdf.Layout/BlockLayout.cs
+++ b/src/EggPdf.Layout/BlockLayout.cs
@@ -11,6 +11,9 @@ namespace EggPdf.Layout;
 public static class BlockLayout
 {
     private const float DefaultFontSize = 16f;
+
+    /// <summary>U+00A0 — rendered content, never a collapsible boundary space.</summary>
+    private const char NonBreakingSpace = (char)0x00A0;
     private const float DefaultLineHeight = 1.2f;
 
     // Thread-local context for ::before/::after and CSS counters.
@@ -826,8 +829,9 @@ public static class BlockLayout
                             inlineLineHeight = ilLineHeight;
                     }
 
-                    prevTextEndedWithSpace = textNode.Data.Length > 0 &&
-                        char.IsWhiteSpace(textNode.Data[textNode.Data.Length - 1]);
+                    // NBSP is rendered content, not a collapsible boundary space
+                    char ilLastChar = textNode.Data.Length > 0 ? textNode.Data[textNode.Data.Length - 1] : '\0';
+                    prevTextEndedWithSpace = ilLastChar != NonBreakingSpace && char.IsWhiteSpace(ilLastChar);
                     continue;
                 }
 
@@ -2375,7 +2379,7 @@ public static class BlockLayout
                     Style = parentStyle,
                     Element = null,
                     FontSize = parentFontSize,
-                    HasLeadingSpace = data.Length > 0 && char.IsWhiteSpace(data[0])
+                    HasLeadingSpace = data.Length > 0 && data[0] != NonBreakingSpace && char.IsWhiteSpace(data[0])
                 });
             }
             return;
@@ -2593,8 +2597,9 @@ public static class BlockLayout
                 firstWord = false;
             }
 
-            prevRunTrailingSpace = run.Text.Length > 0 &&
-                char.IsWhiteSpace(run.Text[run.Text.Length - 1]);
+            // NBSP is rendered content, not a collapsible boundary space
+            char lastRunChar = run.Text.Length > 0 ? run.Text[run.Text.Length - 1] : '\0';
+            prevRunTrailingSpace = lastRunChar != NonBreakingSpace && char.IsWhiteSpace(lastRunChar);
         }
     }
 

--- a/src/EggPdf.Layout/BlockLayout.cs
+++ b/src/EggPdf.Layout/BlockLayout.cs
@@ -2481,6 +2481,11 @@ public static class BlockLayout
             float runLetterSpacing = ResolveLength(run.Style.Get("letter-spacing"), 0, run.FontSize);
             float lhRun = TextMeasurer.GetLineHeight(run.FontSize, run.Style.Get("line-height"));
 
+            var runOverflowWrap = run.Style.Get("overflow-wrap") ?? run.Style.Get("word-wrap");
+            var runWordBreak = run.Style.Get("word-break");
+            bool runBreakWord = runOverflowWrap == "break-word" || runOverflowWrap == "anywhere" ||
+                                runWordBreak == "break-all" || runWordBreak == "break-word";
+
             // Iterate words inline — avoids allocating a string[] upfront.
             int wPos = 0;
             bool firstWord = true;
@@ -2508,6 +2513,56 @@ public static class BlockLayout
                     inlineLineHeight = 0;
                     wordText = word; // no space prefix after wrap
                     wordWidth = TextMeasurer.MeasureWidth(wordText, run.FontSize, fontFamily, fontWeight, fontStyle, runLetterSpacing);
+                }
+
+                // break-all / break-word: a word wider than the line splits into
+                // character chunks that each fit (e.g. long URLs in captions)
+                if (runBreakWord && wordWidth > containerWidth && wordText.Length > 1)
+                {
+                    int start = 0;
+                    while (start < wordText.Length)
+                    {
+                        int len = 1;
+                        float chunkWidth = TextMeasurer.MeasureWidth(wordText.Substring(start, 1),
+                            run.FontSize, fontFamily, fontWeight, fontStyle, runLetterSpacing);
+                        while (start + len < wordText.Length)
+                        {
+                            float nextWidth = TextMeasurer.MeasureWidth(wordText.Substring(start, len + 1),
+                                run.FontSize, fontFamily, fontWeight, fontStyle, runLetterSpacing);
+                            if (inlineX + nextWidth > containerWidth) break;
+                            len++;
+                            chunkWidth = nextWidth;
+                        }
+
+                        var chunkBox = new LayoutBox
+                        {
+                            Element = (!elementAssigned && wrapperElement != null) ? wrapperElement : null,
+                            Style = run.Style,
+                            X = box.X + box.PaddingLeft + inlineX,
+                            Y = box.Y + box.PaddingTop + childY,
+                            Width = chunkWidth,
+                            Height = lhRun,
+                            ContentWidth = chunkWidth,
+                            ContentHeight = lhRun,
+                            Text = wordText.Substring(start, len)
+                        };
+                        if (!elementAssigned && wrapperElement != null)
+                            elementAssigned = true;
+                        box.Children.Add(chunkBox);
+                        inlineX += chunkWidth;
+                        if (lhRun > inlineLineHeight)
+                            inlineLineHeight = lhRun;
+
+                        start += len;
+                        if (start < wordText.Length)
+                        {
+                            childY += inlineLineHeight > 0 ? inlineLineHeight : lhRun;
+                            inlineX = 0;
+                            inlineLineHeight = 0;
+                        }
+                    }
+                    firstWord = false;
+                    continue;
                 }
 
                 var textBox = new LayoutBox

--- a/src/EggPdf.Layout/BlockLayout.cs
+++ b/src/EggPdf.Layout/BlockLayout.cs
@@ -711,6 +711,26 @@ public static class BlockLayout
                 {
                     // Inline-block: create a box that flows inline but has block internals
                     var childBox = CreateBox(childElem, childStyle, box, childContainingWidth, resolver, style);
+
+                    // Shrink-to-fit: an auto-width inline-block wraps its content
+                    // (CSS 2.1 §10.3.9) instead of filling the containing block.
+                    if (string.IsNullOrEmpty(childStyle.Width) || childStyle.Width == "auto")
+                    {
+                        float contentRight = childBox.X + childBox.PaddingLeft;
+                        for (int ci = 0; ci < childBox.Children.Count; ci++)
+                        {
+                            float r = childBox.Children[ci].X + childBox.Children[ci].Width;
+                            if (r > contentRight) contentRight = r;
+                        }
+                        float shrunk = contentRight - childBox.X + childBox.PaddingRight;
+                        if (shrunk > 0 && shrunk < childBox.Width)
+                        {
+                            childBox.Width = shrunk;
+                            childBox.ContentWidth = shrunk - childBox.PaddingLeft - childBox.PaddingRight;
+                            if (childBox.ContentWidth < 0) childBox.ContentWidth = 0;
+                        }
+                    }
+
                     float ibWidth = childBox.Width;
                     if (inlineX > 0 && inlineX + ibWidth > childContainingWidth)
                     {
@@ -718,9 +738,21 @@ public static class BlockLayout
                         inlineX = 0;
                         inlineLineHeight = 0;
                     }
+
+                    // text-align on the parent positions the inline-block within the line
+                    float ibAlignOffset = 0;
+                    if (inlineX == 0 && ibWidth < childContainingWidth)
+                    {
+                        var parentTextAlign = style.Get("text-align");
+                        if (parentTextAlign == "center")
+                            ibAlignOffset = (childContainingWidth - ibWidth) / 2;
+                        else if (parentTextAlign == "right")
+                            ibAlignOffset = childContainingWidth - ibWidth;
+                    }
+
                     // X is absolute (shift descendants); Y is parent-relative and
                     // resolved in the post-layout pass.
-                    float ibDeltaX = box.X + box.PaddingLeft + inlineX - childBox.X;
+                    float ibDeltaX = box.X + box.PaddingLeft + inlineX + ibAlignOffset - childBox.X;
                     childBox.X += ibDeltaX;
                     childBox.Y = box.Y + box.PaddingTop + childY;
                     if (Math.Abs(ibDeltaX) > 0.01f)

--- a/src/EggPdf.Layout/FlexLayout.cs
+++ b/src/EggPdf.Layout/FlexLayout.cs
@@ -820,6 +820,30 @@ public static class FlexLayout
         float freeSpace = mainSize - totalItemMain - totalGap;
         if (freeSpace < 0) freeSpace = 0;
 
+        // Auto margins absorb positive free space before justify-content
+        // (CSS Flexbox §8.1) — margin-top:auto pushes a footer to the bottom.
+        int autoMarginCount = 0;
+        for (int i = 0; i < line.Items.Count; i++)
+        {
+            var st = line.Items[i].Style;
+            if (isRow)
+            {
+                if (st.Get("margin-left") == "auto") autoMarginCount++;
+                if (st.Get("margin-right") == "auto") autoMarginCount++;
+            }
+            else
+            {
+                if (st.Get("margin-top") == "auto") autoMarginCount++;
+                if (st.Get("margin-bottom") == "auto") autoMarginCount++;
+            }
+        }
+        float autoMarginShare = 0;
+        if (autoMarginCount > 0 && freeSpace > 0)
+        {
+            autoMarginShare = freeSpace / autoMarginCount;
+            freeSpace = 0;
+        }
+
         // Compute initial offset and spacing based on justify-content
         float mainOffset;
         float extraGap;
@@ -835,6 +859,8 @@ public static class FlexLayout
 
             if (isRow)
             {
+                if (autoMarginShare > 0 && item.Style.Get("margin-left") == "auto")
+                    pos += autoMarginShare;
                 pos += item.Box.MarginLeft;
                 float newX = container.X + container.PaddingLeft + pos;
                 float deltaX = newX - item.Box.X;
@@ -843,14 +869,20 @@ public static class FlexLayout
                 if (Math.Abs(deltaX) > 0.01f)
                     OffsetChildren(item.Box, deltaX, 0);
                 pos += item.MainSize + item.Box.MarginRight;
+                if (autoMarginShare > 0 && item.Style.Get("margin-right") == "auto")
+                    pos += autoMarginShare;
             }
             else
             {
+                if (autoMarginShare > 0 && item.Style.Get("margin-top") == "auto")
+                    pos += autoMarginShare;
                 pos += item.Box.MarginTop;
                 // Child Y coordinates are parent-relative (the post-layout pass in
                 // BlockLayout adds each ancestor's Y), so only the box moves here.
                 item.Box.Y = container.Y + container.PaddingTop + pos;
                 pos += item.MainSize + item.Box.MarginBottom;
+                if (autoMarginShare > 0 && item.Style.Get("margin-bottom") == "auto")
+                    pos += autoMarginShare;
             }
 
             // Add gap between items (not after last)

--- a/src/EggPdf.Layout/FlexLayout.cs
+++ b/src/EggPdf.Layout/FlexLayout.cs
@@ -943,8 +943,26 @@ public static class FlexLayout
                     break;
 
                 case "baseline":
-                    // Simplified baseline: treat as flex-start
-                    crossPos = lineCrossOffset + itemMarginBefore;
+                    if (isRow)
+                    {
+                        // Align first baselines (ascent approximated at 0.8em of
+                        // each item's font size)
+                        float maxAscent = 0;
+                        for (int bi = 0; bi < line.Items.Count; bi++)
+                        {
+                            float fs = BlockLayout.ResolveFontSize(line.Items[bi].Style.FontSize, DefaultFontSize);
+                            float asc = fs * 0.8f + line.Items[bi].Box.MarginTop;
+                            if (asc > maxAscent) maxAscent = asc;
+                        }
+                        float itemAscent = BlockLayout.ResolveFontSize(item.Style.FontSize, DefaultFontSize) * 0.8f
+                            + itemMarginBefore;
+                        crossPos = lineCrossOffset + itemMarginBefore + (maxAscent - itemAscent);
+                    }
+                    else
+                    {
+                        // Column direction: baseline falls back to flex-start
+                        crossPos = lineCrossOffset + itemMarginBefore;
+                    }
                     break;
 
                 case "stretch":

--- a/src/EggPdf.Layout/FlexLayout.cs
+++ b/src/EggPdf.Layout/FlexLayout.cs
@@ -203,11 +203,104 @@ public static class FlexLayout
     {
         var items = new List<FlexItem>();
 
+        // Direct text (and <br>) children form an anonymous flex item (CSS Flexbox §4)
+        var anonLines = new List<string>();
+        var anonCurrent = new System.Text.StringBuilder();
+
+        void FlushAnonymousItem()
+        {
+            if (anonCurrent.Length > 0)
+            {
+                anonLines.Add(anonCurrent.ToString());
+                anonCurrent.Clear();
+            }
+            bool hasContent = false;
+            for (int li = 0; li < anonLines.Count; li++)
+                if (anonLines[li].Length > 0) { hasContent = true; break; }
+            if (!hasContent) { anonLines.Clear(); return; }
+
+            var fam = containerStyle.FontFamily;
+            var wt = containerStyle.FontWeight;
+            var fs = containerStyle.Get("font-style");
+            float ls = BlockLayout.ResolveLength(containerStyle.Get("letter-spacing"), 0, fontSize);
+            float lineH = TextMeasurer.GetLineHeight(fontSize, containerStyle.Get("line-height"));
+            bool centerLines = containerStyle.Get("text-align") == "center";
+
+            float maxW = 0;
+            for (int li = 0; li < anonLines.Count; li++)
+            {
+                float w = anonLines[li].Length > 0
+                    ? TextMeasurer.MeasureWidth(anonLines[li], fontSize, fam, wt, fs, ls) : 0;
+                if (w > maxW) maxW = w;
+            }
+
+            var anonBox = new LayoutBox { Style = containerStyle };
+            float y = 0;
+            for (int li = 0; li < anonLines.Count; li++)
+            {
+                var line = anonLines[li];
+                float w = line.Length > 0 ? TextMeasurer.MeasureWidth(line, fontSize, fam, wt, fs, ls) : 0;
+                anonBox.Children.Add(new LayoutBox
+                {
+                    Style = containerStyle,
+                    Text = line.Length > 0 ? line : null,
+                    X = centerLines ? (maxW - w) / 2 : 0,
+                    Y = y,
+                    Width = w,
+                    Height = lineH,
+                    ContentWidth = w,
+                    ContentHeight = lineH
+                });
+                y += lineH;
+            }
+            anonBox.Width = maxW;
+            anonBox.ContentWidth = maxW;
+            anonBox.Height = y;
+            anonBox.ContentHeight = y;
+
+            items.Add(new FlexItem
+            {
+                Box = anonBox,
+                Element = null!,
+                Style = containerStyle,
+                FlexGrow = 0,
+                FlexShrink = 1,
+                BaseSize = isRow ? maxW : y,
+                HypotheticalMainSize = isRow ? maxW : y,
+                Order = 0,
+                AlignSelf = null,
+                MinMain = 0,
+                MaxMain = float.MaxValue,
+                SourceIndex = items.Count,
+                InitialBoxWidth = maxW
+            });
+            anonLines.Clear();
+        }
+
         for (int i = 0; i < element.ChildNodes.Count; i++)
         {
             var childNode = element.ChildNodes[i];
+
+            if (childNode is HtmlTextNode textNode)
+            {
+                var t = textNode.Data.Trim();
+                if (t.Length > 0)
+                {
+                    if (anonCurrent.Length > 0) anonCurrent.Append(' ');
+                    anonCurrent.Append(t);
+                }
+                continue;
+            }
+
             if (!(childNode is HtmlElement childElem))
                 continue;
+
+            if (childElem.TagName == "br")
+            {
+                anonLines.Add(anonCurrent.ToString());
+                anonCurrent.Clear();
+                continue;
+            }
 
             var childStyle = resolver(childElem, containerStyle);
             if (childStyle.Display == "none")
@@ -219,6 +312,9 @@ public static class FlexLayout
             var childPosition = childStyle.Get("position");
             if (childPosition == "absolute" || childPosition == "fixed")
                 continue;
+
+            // An element child ends any pending anonymous text item
+            FlushAnonymousItem();
 
             // Read flex item properties
             float flexGrow = ParseFloatSafe(childStyle.Get("flex-grow"), 0);
@@ -325,6 +421,9 @@ public static class FlexLayout
                 InitialBoxWidth = childBox.Width
             });
         }
+
+        // Trailing text content also forms an anonymous item
+        FlushAnonymousItem();
 
         return items;
     }
@@ -652,6 +751,8 @@ public static class FlexLayout
         for (int i = 0; i < line.Items.Count; i++)
         {
             var item = line.Items[i];
+            // Anonymous text items have no element to re-lay-out
+            if (item.Element == null) continue;
             // Skip items whose width didn't change (explicit-width items that kept their size)
             if (Math.Abs(item.Box.Width - item.InitialBoxWidth) < 0.5f) continue;
 

--- a/src/EggPdf.Layout/FlexLayout.cs
+++ b/src/EggPdf.Layout/FlexLayout.cs
@@ -909,6 +909,9 @@ public static class FlexLayout
         Func<HtmlElement, ComputedStyle?, ComputedStyle> resolver, float fontSize)
     {
         float maxWidth = 0;
+        float inlineRun = 0; // consecutive inline content shares one line (max-content)
+        float letterSpacing = BlockLayout.ResolveLength(style.Get("letter-spacing"), 0, fontSize);
+        var textTransform = style.Get("text-transform");
 
         for (int i = 0; i < element.ChildNodes.Count; i++)
         {
@@ -917,30 +920,49 @@ public static class FlexLayout
             {
                 var text = textNode.Data.Trim();
                 if (string.IsNullOrEmpty(text)) continue;
-                float textWidth = TextMeasurer.MeasureWidth(text, fontSize,
-                    style.FontFamily, style.FontWeight, style.Get("font-style"));
-                if (textWidth > maxWidth) maxWidth = textWidth;
+                if (textTransform == "uppercase") text = text.ToUpperInvariant();
+                else if (textTransform == "lowercase") text = text.ToLowerInvariant();
+                if (inlineRun > 0)
+                    inlineRun += TextMeasurer.MeasureWidth(" ", fontSize,
+                        style.FontFamily, style.FontWeight, style.Get("font-style"), letterSpacing);
+                inlineRun += TextMeasurer.MeasureWidth(text, fontSize,
+                    style.FontFamily, style.FontWeight, style.Get("font-style"), letterSpacing);
             }
             else if (child is HtmlElement childElem)
             {
                 var childStyle = resolver(childElem, style);
                 if (childStyle.Display == "none") continue;
 
-                // Check for explicit width
+                float childWidth;
                 var explicitWidth = BlockLayout.ResolveOptionalLength(childStyle.Width, 0, fontSize);
                 if (explicitWidth.HasValue)
                 {
-                    if (explicitWidth.Value > maxWidth) maxWidth = explicitWidth.Value;
+                    childWidth = explicitWidth.Value;
                 }
                 else
                 {
                     float childFontSize = BlockLayout.ResolveFontSize(childStyle.FontSize, fontSize);
-                    float childContentWidth = MeasureContentWidth(childElem, childStyle, resolver, childFontSize);
-                    if (childContentWidth > maxWidth) maxWidth = childContentWidth;
+                    childWidth = MeasureContentWidth(childElem, childStyle, resolver, childFontSize);
+                }
+
+                bool isInline = childStyle.Display == "inline" || childStyle.Display == "inline-block";
+                if (isInline)
+                {
+                    if (inlineRun > 0)
+                        inlineRun += TextMeasurer.MeasureWidth(" ", fontSize,
+                            style.FontFamily, style.FontWeight, style.Get("font-style"), letterSpacing);
+                    inlineRun += childWidth;
+                }
+                else
+                {
+                    if (inlineRun > maxWidth) maxWidth = inlineRun;
+                    inlineRun = 0;
+                    if (childWidth > maxWidth) maxWidth = childWidth;
                 }
             }
         }
 
+        if (inlineRun > maxWidth) maxWidth = inlineRun;
         return maxWidth;
     }
 

--- a/src/EggPdf.Layout/FlexLayout.cs
+++ b/src/EggPdf.Layout/FlexLayout.cs
@@ -42,7 +42,7 @@ public static class FlexLayout
         float mainGap = ResolveGap(style, isRow, container.ContentWidth, fontSize);
         float crossGap = ResolveGap(style, !isRow, container.ContentWidth, fontSize);
 
-        float mainSize = isRow ? container.ContentWidth : GetContainerCrossSize(container, style, isRow, fontSize);
+        float mainSize = isRow ? container.ContentWidth : GetColumnMainSize(container, style, fontSize);
         float crossSize = isRow ? GetContainerCrossSize(container, style, isRow, fontSize) : container.ContentWidth;
 
         // Collect flex items
@@ -53,13 +53,18 @@ public static class FlexLayout
         // Sort by order property
         SortByOrder(items);
 
+        // An auto-height column container has an indefinite main size: items keep
+        // their hypothetical sizes (no grow/shrink, no justify free space).
+        bool mainIndefinite = !isRow && mainSize <= 0;
+
         // Collect items into flex lines
-        var lines = CollectFlexLines(items, mainSize, mainGap, isWrap, isRow);
+        var lines = CollectFlexLines(items, mainIndefinite ? float.MaxValue : mainSize, mainGap, isWrap, isRow);
 
         // Resolve flexible lengths for each line
         for (int li = 0; li < lines.Count; li++)
         {
-            ResolveFlexibleLengths(lines[li], mainSize, mainGap, isRow);
+            float lineMain = mainIndefinite ? SumLineBaseMain(lines[li], mainGap, isRow) : mainSize;
+            ResolveFlexibleLengths(lines[li], lineMain, mainGap, isRow);
         }
 
         // Re-layout items whose width changed from the initial CreateBox pass.
@@ -94,7 +99,8 @@ public static class FlexLayout
             float lineCrossOffset = lineOffsets[lineIdx];
 
             // Main axis alignment
-            PositionMainAxis(line, mainSize, mainGap, justifyContent, isRow, isReverse, container);
+            float positionMain = mainIndefinite ? SumLineBaseMain(line, mainGap, isRow) : mainSize;
+            PositionMainAxis(line, positionMain, mainGap, justifyContent, isRow, isReverse, container);
 
             // Cross axis alignment
             PositionCrossAxis(line, lineCrossOffset, line.CrossSize, alignItems, isRow, container);
@@ -139,6 +145,41 @@ public static class FlexLayout
         return BlockLayout.ResolveLength(gapValue, containingWidth, fontSize);
     }
 
+    /// <summary>
+    /// Main size of a column flex container: its definite height, else min-height,
+    /// else 0 (auto — content-driven, no free space to distribute).
+    /// </summary>
+    private static float GetColumnMainSize(LayoutBox container, ComputedStyle style, float fontSize)
+    {
+        var h = BlockLayout.ResolveOptionalLength(style.Height, 0, fontSize)
+             ?? BlockLayout.ResolveOptionalLength(style.Get("min-height"), 0, fontSize);
+        if (!h.HasValue) return 0;
+
+        // Items are laid out inside the padding, so a border-box height must be
+        // reduced to the content height.
+        if (style.Get("box-sizing") == "border-box")
+        {
+            float content = h.Value - container.PaddingTop - container.PaddingBottom;
+            return content > 0 ? content : 0;
+        }
+        return h.Value;
+    }
+
+    /// <summary>Sum of a line's hypothetical item sizes, margins, and gaps along the main axis.</summary>
+    private static float SumLineBaseMain(FlexLine line, float mainGap, bool isRow)
+    {
+        float total = line.Items.Count > 1 ? mainGap * (line.Items.Count - 1) : 0;
+        for (int i = 0; i < line.Items.Count; i++)
+        {
+            var item = line.Items[i];
+            total += item.HypotheticalMainSize;
+            total += isRow
+                ? item.Box.MarginLeft + item.Box.MarginRight
+                : item.Box.MarginTop + item.Box.MarginBottom;
+        }
+        return total;
+    }
+
     /// <summary>Get container's cross size (height for row, width for column).</summary>
     private static float GetContainerCrossSize(LayoutBox container, ComputedStyle style, bool isRow, float fontSize)
     {
@@ -172,6 +213,13 @@ public static class FlexLayout
             if (childStyle.Display == "none")
                 continue;
 
+            // Absolutely/fixed positioned children are out-of-flow: they are not
+            // flex items and must not consume flex space. The container's CreateBox
+            // branch positions them after the flex layout completes.
+            var childPosition = childStyle.Get("position");
+            if (childPosition == "absolute" || childPosition == "fixed")
+                continue;
+
             // Read flex item properties
             float flexGrow = ParseFloatSafe(childStyle.Get("flex-grow"), 0);
             float flexShrink = ParseFloatSafe(childStyle.Get("flex-shrink"), 1);
@@ -194,9 +242,10 @@ public static class FlexLayout
                 hasExplicitMainSize = !string.IsNullOrEmpty(childStyle.Height) && childStyle.Height != "auto";
             }
 
-            // Create child box using BlockLayout
+            // Create child box using BlockLayout. Items resolve their widths against
+            // the flex container's content box, not the container's own containing block.
             var childBox = BlockLayout.CreateBox(childElem, childStyle, container,
-                containingWidth, resolver, containerStyle);
+                container.ContentWidth, resolver, containerStyle);
 
             // Determine base size
             float baseSize;
@@ -227,7 +276,12 @@ public static class FlexLayout
                 // the baseSize incorrectly. Leaf text runs have ContentWidth = measured text width.
                 if (isRow)
                 {
-                    baseSize = GetMaxLeafContentWidth(childBox);
+                    // Max-content sizing: leaf runs are word-level after wrapping, so
+                    // also measure the unwrapped text width (flex-shrink recovers
+                    // overflow when the sum exceeds the line).
+                    baseSize = Math.Max(GetMaxLeafContentWidth(childBox),
+                        MeasureContentWidth(childElem, childStyle, resolver,
+                            BlockLayout.ResolveFontSize(childStyle.FontSize, fontSize)));
                 }
                 else
                 {
@@ -669,11 +723,9 @@ public static class FlexLayout
             else
             {
                 pos += item.Box.MarginTop;
-                float newY = container.Y + container.PaddingTop + pos;
-                float deltaY = newY - item.Box.Y;
-                item.Box.Y = newY;
-                if (Math.Abs(deltaY) > 0.01f)
-                    OffsetChildren(item.Box, 0, deltaY);
+                // Child Y coordinates are parent-relative (the post-layout pass in
+                // BlockLayout adds each ancestor's Y), so only the box moves here.
+                item.Box.Y = container.Y + container.PaddingTop + pos;
                 pos += item.MainSize + item.Box.MarginBottom;
             }
 
@@ -825,11 +877,9 @@ public static class FlexLayout
 
             if (isRow)
             {
-                float newY = container.Y + container.PaddingTop + crossPos;
-                float deltaY = newY - item.Box.Y;
-                item.Box.Y = newY;
-                if (Math.Abs(deltaY) > 0.01f)
-                    OffsetChildren(item.Box, 0, deltaY);
+                // Child Y coordinates are parent-relative (resolved in a post-layout
+                // pass), so only the box itself moves vertically.
+                item.Box.Y = container.Y + container.PaddingTop + crossPos;
             }
             else
             {
@@ -843,7 +893,7 @@ public static class FlexLayout
     }
 
     /// <summary>Recursively offset all children by delta X/Y when parent is repositioned.</summary>
-    private static void OffsetChildren(LayoutBox box, float dx, float dy)
+    internal static void OffsetChildren(LayoutBox box, float dx, float dy)
     {
         for (int i = 0; i < box.Children.Count; i++)
         {

--- a/src/EggPdf.Layout/FlexLayout.cs
+++ b/src/EggPdf.Layout/FlexLayout.cs
@@ -1052,7 +1052,9 @@ public static class FlexLayout
                     if (inlineRun > 0)
                         inlineRun += TextMeasurer.MeasureWidth(" ", fontSize,
                             style.FontFamily, style.FontWeight, style.Get("font-style"), letterSpacing);
-                    inlineRun += childWidth;
+                    inlineRun += childWidth
+                        + BlockLayout.ResolveLength(childStyle.Get("margin-left"), 0, fontSize)
+                        + BlockLayout.ResolveLength(childStyle.Get("margin-right"), 0, fontSize);
                 }
                 else
                 {

--- a/src/EggPdf.Layout/FlexLayout.cs
+++ b/src/EggPdf.Layout/FlexLayout.cs
@@ -495,10 +495,18 @@ public static class FlexLayout
         float totalGap = line.Items.Count > 1 ? mainGap * (line.Items.Count - 1) : 0;
         float availableMain = mainSize - totalGap;
 
-        // Sum of hypothetical main sizes
+        // Sum of hypothetical main sizes INCLUDING main-axis margins — margins
+        // occupy main-axis space (PositionMainAxis advances past them), so
+        // ignoring them over-grows flex items and pushes later ones off the edge.
         float totalHypothetical = 0;
         for (int i = 0; i < line.Items.Count; i++)
-            totalHypothetical += line.Items[i].HypotheticalMainSize;
+        {
+            var it = line.Items[i];
+            totalHypothetical += it.HypotheticalMainSize;
+            totalHypothetical += isRow
+                ? it.Box.MarginLeft + it.Box.MarginRight
+                : it.Box.MarginTop + it.Box.MarginBottom;
+        }
 
         float freeSpace = availableMain - totalHypothetical;
 

--- a/src/EggPdf.Layout/FlexLayout.cs
+++ b/src/EggPdf.Layout/FlexLayout.cs
@@ -226,6 +226,21 @@ public static class FlexLayout
             float lineH = TextMeasurer.GetLineHeight(fontSize, containerStyle.Get("line-height"));
             bool centerLines = containerStyle.Get("text-align") == "center";
 
+            // Anonymous boxes carry only inherited text properties — copying the
+            // container's borders/backgrounds would paint its decorations twice
+            // (e.g. a second circle inside a round stamp).
+            var anonStyle = new ComputedStyle();
+            foreach (var kv in containerStyle.All)
+            {
+                if (kv.Key.StartsWith("border", StringComparison.Ordinal) ||
+                    kv.Key.StartsWith("background", StringComparison.Ordinal) ||
+                    kv.Key.StartsWith("box-shadow", StringComparison.Ordinal) ||
+                    kv.Key.StartsWith("outline", StringComparison.Ordinal) ||
+                    kv.Key.StartsWith("padding", StringComparison.Ordinal))
+                    continue;
+                anonStyle.Set(kv.Key, kv.Value);
+            }
+
             float maxW = 0;
             for (int li = 0; li < anonLines.Count; li++)
             {
@@ -234,7 +249,7 @@ public static class FlexLayout
                 if (w > maxW) maxW = w;
             }
 
-            var anonBox = new LayoutBox { Style = containerStyle };
+            var anonBox = new LayoutBox { Style = anonStyle };
             float y = 0;
             for (int li = 0; li < anonLines.Count; li++)
             {
@@ -242,7 +257,7 @@ public static class FlexLayout
                 float w = line.Length > 0 ? TextMeasurer.MeasureWidth(line, fontSize, fam, wt, fs, ls) : 0;
                 anonBox.Children.Add(new LayoutBox
                 {
-                    Style = containerStyle,
+                    Style = anonStyle,
                     Text = line.Length > 0 ? line : null,
                     X = centerLines ? (maxW - w) / 2 : 0,
                     Y = y,
@@ -262,7 +277,7 @@ public static class FlexLayout
             {
                 Box = anonBox,
                 Element = null!,
-                Style = containerStyle,
+                Style = anonStyle,
                 FlexGrow = 0,
                 FlexShrink = 1,
                 BaseSize = isRow ? maxW : y,

--- a/src/EggPdf.Layout/GridLayout.cs
+++ b/src/EggPdf.Layout/GridLayout.cs
@@ -261,8 +261,14 @@ public static class GridLayout
                 if (r > item.RowStart) cellHeight += rowGap;
             }
 
+            // Move the item box to its cell. X coordinates are absolute, so the
+            // already-laid-out descendants shift with the box; Y coordinates are
+            // parent-relative and get resolved in BlockLayout's post-layout pass.
+            float deltaX = cellX - item.Box.X;
             item.Box.X = cellX;
             item.Box.Y = cellY;
+            if (Math.Abs(deltaX) > 0.01f)
+                FlexLayout.OffsetChildren(item.Box, deltaX, 0);
             item.Box.Width = cellWidth;
             item.Box.ContentWidth = cellWidth - item.Box.PaddingLeft - item.Box.PaddingRight;
             if (item.Box.ContentWidth < 0) item.Box.ContentWidth = 0;
@@ -320,6 +326,11 @@ public static class GridLayout
 
             var childStyle = resolver(childElem, containerStyle);
             if (childStyle.Display == "none")
+                continue;
+
+            // Absolutely/fixed positioned children are out-of-flow, not grid items.
+            var childPosition = childStyle.Get("position");
+            if (childPosition == "absolute" || childPosition == "fixed")
                 continue;
 
             var item = new GridItem

--- a/src/EggPdf.Layout/StandardFontMetrics.cs
+++ b/src/EggPdf.Layout/StandardFontMetrics.cs
@@ -137,6 +137,29 @@ public static class StandardFontMetrics
         bool bold = fontWeight == "bold" || fontWeight == "700" || fontWeight == "800" || fontWeight == "900";
         bool italic = fontStyle == "italic" || fontStyle == "oblique";
 
+        // When webfonts are in play (measurement provider active), intermediate
+        // numeric weights select their own face: the name carries the weight
+        // ("Arial-W600") so each weight embeds and paints its matching variant.
+        int numericWeight = 0;
+        if (!string.IsNullOrEmpty(fontWeight))
+            int.TryParse(fontWeight, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out numericWeight);
+        bool weightVariant = TextMeasurer.FontDataProvider != null &&
+            numericWeight >= 100 && numericWeight <= 900 &&
+            numericWeight != 400 && numericWeight != 700;
+        if (weightVariant)
+        {
+            bold = false; // the weight suffix carries the variant instead
+            var baseName = ResolveBaseFontName(fontFamily, false, italic);
+            return baseName + "-W" + numericWeight;
+        }
+
+        return ResolveBaseFontName(fontFamily, bold, italic);
+    }
+
+    private static string ResolveBaseFontName(string? fontFamily, bool bold, bool italic)
+    {
+
         var family = (fontFamily ?? "").ToLowerInvariant().Trim();
 
         if (family.IndexOf("monospace", StringComparison.OrdinalIgnoreCase) >= 0 ||

--- a/src/EggPdf.Layout/TextMeasurer.cs
+++ b/src/EggPdf.Layout/TextMeasurer.cs
@@ -90,6 +90,30 @@ public static class TextMeasurer
         return width;
     }
 
+    /// <summary>
+    /// Baseline offset from the line-box top: half-leading plus ascent, using the
+    /// real font's metrics when a webfont provider is active (falls back to the
+    /// 0.86em/0.14em approximation for built-in fonts).
+    /// </summary>
+    public static float GetBaselineOffset(float fontSize, float lineBoxHeight,
+        string? fontFamily, string? fontWeight, string? fontStyle)
+    {
+        float asc = 0.86f, desc = 0.14f;
+        var fd = FontDataProvider?.Invoke(fontFamily, fontWeight, fontStyle);
+        if (fd != null && fd.UnitsPerEm > 0 && fd.Ascent > 0)
+        {
+            float a = (float)fd.Ascent / fd.UnitsPerEm;
+            float d = Math.Abs((float)fd.Descent) / fd.UnitsPerEm;
+            if (a >= 0.5f && a <= 1.2f && d <= 0.6f)
+            {
+                asc = a;
+                desc = d;
+            }
+        }
+        float halfLeading = (lineBoxHeight - (asc + desc) * fontSize) / 2f;
+        return halfLeading + asc * fontSize;
+    }
+
     /// <summary>Count glyphs (surrogate pairs form one glyph).</summary>
     private static int CountGlyphs(string text)
     {

--- a/src/EggPdf.Layout/TextMeasurer.cs
+++ b/src/EggPdf.Layout/TextMeasurer.cs
@@ -15,6 +15,15 @@ public static class TextMeasurer
     /// <summary>Shared English hyphenator (thread-safe: immutable after construction).</summary>
     private static readonly Hyphenator _englishHyphenator = Hyphenator.CreateEnglish();
 
+    /// <summary>
+    /// Optional per-render provider resolving (font-family list, weight, style)
+    /// to a real parsed font whose advance widths are used for measurement.
+    /// Set by the render pipeline when @font-face webfonts are in play, so
+    /// layout measures with the same glyph metrics the PDF paints with.
+    /// </summary>
+    [ThreadStatic]
+    public static Func<string?, string?, string?, EggPdf.Text.TrueType.FontData?>? FontDataProvider;
+
     /// <summary>Measure the width of text in pixels using standard font metrics.</summary>
     public static float MeasureWidth(string text, float fontSize, string? fontFamily)
     {
@@ -25,10 +34,73 @@ public static class TextMeasurer
     public static float MeasureWidth(string text, float fontSize, string? fontFamily,
         string? fontWeight, string? fontStyle)
     {
+        return MeasureWidth(text, fontSize, fontFamily, fontWeight, fontStyle, 0f);
+    }
+
+    /// <summary>
+    /// Measure the width of text including letter-spacing. The PDF Tc operator
+    /// applies spacing after every glyph (including the last), so measurement
+    /// adds letterSpacing per glyph to match painting.
+    /// </summary>
+    public static float MeasureWidth(string text, float fontSize, string? fontFamily,
+        string? fontWeight, string? fontStyle, float letterSpacing)
+    {
         if (string.IsNullOrEmpty(text)) return 0;
 
-        var pdfFont = StandardFontMetrics.ResolvePdfFontName(fontFamily, fontWeight, fontStyle);
-        return StandardFontMetrics.MeasureWidth(text, fontSize, pdfFont);
+        float width;
+        int glyphCount = 0;
+
+        var fontData = FontDataProvider?.Invoke(fontFamily, fontWeight, fontStyle);
+        if (fontData != null && fontData.UnitsPerEm > 0)
+        {
+            // Real font metrics (webfont) — matches what the PDF will paint
+            var pdfFont = StandardFontMetrics.ResolvePdfFontName(fontFamily, fontWeight, fontStyle);
+            float w = 0;
+            for (int i = 0; i < text.Length; i++)
+            {
+                int cp = text[i];
+                if (char.IsHighSurrogate(text[i]) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
+                {
+                    cp = char.ConvertToUtf32(text[i], text[i + 1]);
+                    i++;
+                }
+                glyphCount++;
+
+                var gid = fontData.GetGlyphId(cp);
+                if (gid > 0)
+                    w += fontData.GetAdvanceWidth(gid) * fontSize / fontData.UnitsPerEm;
+                else if (cp <= char.MaxValue)
+                    w += StandardFontMetrics.MeasureCharWidth((char)cp, fontSize, pdfFont);
+                else
+                    w += fontSize * 0.5f;
+            }
+            width = w;
+        }
+        else
+        {
+            var pdfFont = StandardFontMetrics.ResolvePdfFontName(fontFamily, fontWeight, fontStyle);
+            width = StandardFontMetrics.MeasureWidth(text, fontSize, pdfFont);
+            if (letterSpacing != 0)
+                glyphCount = CountGlyphs(text);
+        }
+
+        if (letterSpacing != 0)
+            width += letterSpacing * glyphCount;
+
+        return width;
+    }
+
+    /// <summary>Count glyphs (surrogate pairs form one glyph).</summary>
+    private static int CountGlyphs(string text)
+    {
+        int count = 0;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (char.IsHighSurrogate(text[i]) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
+                i++;
+            count++;
+        }
+        return count;
     }
 
     /// <summary>Get line height for a font size.</summary>
@@ -83,10 +155,11 @@ public static class TextMeasurer
     /// <summary>
     /// Break text into lines respecting white-space, overflow-wrap/word-break, and optional hyphenation.
     /// When enableHyphenation is true, long words are broken at valid hyphenation points with a '-' appended.
+    /// letterSpacing (px per glyph) is included in width calculations.
     /// </summary>
     public static List<string> WrapText(string text, float fontSize, string? fontFamily,
         string? fontWeight, string? fontStyle, float maxWidth, string whiteSpace, bool breakWord,
-        bool enableHyphenation)
+        bool enableHyphenation, float letterSpacing = 0f)
     {
         var lines = new List<string>();
         if (string.IsNullOrEmpty(text))
@@ -105,7 +178,7 @@ public static class TextMeasurer
 
                 if (allowWrap && maxWidth > 0)
                 {
-                    var wrappedLines = WrapSingleLine(processedLine, fontSize, fontFamily, fontWeight, fontStyle, maxWidth, preserveSpaces, breakWord, enableHyphenation);
+                    var wrappedLines = WrapSingleLine(processedLine, fontSize, fontFamily, fontWeight, fontStyle, maxWidth, preserveSpaces, breakWord, enableHyphenation, letterSpacing);
                     lines.AddRange(wrappedLines);
                 }
                 else
@@ -126,7 +199,7 @@ public static class TextMeasurer
                 if (!string.IsNullOrEmpty(collapsed)) lines.Add(collapsed);
                 return lines;
             }
-            var wrappedLines = WrapSingleLine(collapsed, fontSize, fontFamily, fontWeight, fontStyle, maxWidth, false, breakWord, enableHyphenation);
+            var wrappedLines = WrapSingleLine(collapsed, fontSize, fontFamily, fontWeight, fontStyle, maxWidth, false, breakWord, enableHyphenation, letterSpacing);
             lines.AddRange(wrappedLines);
         }
 
@@ -136,7 +209,7 @@ public static class TextMeasurer
     /// <summary>Wrap a single line of text at word boundaries.</summary>
     private static List<string> WrapSingleLine(string text, float fontSize, string? fontFamily,
         string? fontWeight, string? fontStyle, float maxWidth, bool preserveSpaces,
-        bool breakWord = false, bool enableHyphenation = false)
+        bool breakWord = false, bool enableHyphenation = false, float letterSpacing = 0f)
     {
         var lines = new List<string>();
         if (string.IsNullOrEmpty(text))
@@ -161,43 +234,43 @@ public static class TextMeasurer
         if (words.Length == 0) { lines.Add(""); return lines; }
 
         var currentLine = words[0];
-        float currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle);
+        float currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
         // Measure separator width once; reused every iteration to avoid per-word allocation checks.
-        float spaceWidth = preserveSpaces ? 0f : MeasureWidth(" ", fontSize, fontFamily, fontWeight, fontStyle);
+        float spaceWidth = preserveSpaces ? 0f : MeasureWidth(" ", fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
 
         // If first word is too wide, try hyphenation then character-breaking
         if (currentLineWidth > maxWidth)
         {
             if (enableHyphenation)
             {
-                var hyphenated = HyphenateWordToFit(currentLine, "", fontSize, fontFamily, fontWeight, fontStyle, maxWidth);
+                var hyphenated = HyphenateWordToFit(currentLine, "", fontSize, fontFamily, fontWeight, fontStyle, maxWidth, letterSpacing);
                 if (hyphenated != null)
                 {
                     lines.Add(hyphenated.Item1);
                     currentLine = hyphenated.Item2;
-                    currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle);
+                    currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
                 }
                 else if (breakWord)
                 {
-                    var broken = BreakWordByCharacter(currentLine, fontSize, fontFamily, fontWeight, fontStyle, maxWidth);
+                    var broken = BreakWordByCharacter(currentLine, fontSize, fontFamily, fontWeight, fontStyle, maxWidth, letterSpacing);
                     for (int bi = 0; bi < broken.Count - 1; bi++) lines.Add(broken[bi]);
                     currentLine = broken.Count > 0 ? broken[broken.Count - 1] : "";
-                    currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle);
+                    currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
                 }
             }
             else if (breakWord)
             {
-                var broken = BreakWordByCharacter(currentLine, fontSize, fontFamily, fontWeight, fontStyle, maxWidth);
+                var broken = BreakWordByCharacter(currentLine, fontSize, fontFamily, fontWeight, fontStyle, maxWidth, letterSpacing);
                 for (int bi = 0; bi < broken.Count - 1; bi++) lines.Add(broken[bi]);
                 currentLine = broken.Count > 0 ? broken[broken.Count - 1] : "";
-                currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle);
+                currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
             }
         }
 
         for (int i = 1; i < words.Length; i++)
         {
             string word = words[i];
-            float wordWidth = MeasureWidth(word, fontSize, fontFamily, fontWeight, fontStyle);
+            float wordWidth = MeasureWidth(word, fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
             // Check width without building candidate string — only concat when it fits.
             float candidateWidth = currentLineWidth + spaceWidth + wordWidth;
 
@@ -212,12 +285,12 @@ public static class TextMeasurer
                 bool hyphenUsed = false;
                 if (enableHyphenation)
                 {
-                    var hyphenated = HyphenateWordToFit(word, currentLine + separator, fontSize, fontFamily, fontWeight, fontStyle, maxWidth);
+                    var hyphenated = HyphenateWordToFit(word, currentLine + separator, fontSize, fontFamily, fontWeight, fontStyle, maxWidth, letterSpacing);
                     if (hyphenated != null)
                     {
                         lines.Add(hyphenated.Item1);
                         currentLine = hyphenated.Item2;
-                        currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle);
+                        currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
                         hyphenUsed = true;
                     }
                 }
@@ -233,27 +306,27 @@ public static class TextMeasurer
                     {
                         if (enableHyphenation)
                         {
-                            var hyphenated = HyphenateWordToFit(currentLine, "", fontSize, fontFamily, fontWeight, fontStyle, maxWidth);
+                            var hyphenated = HyphenateWordToFit(currentLine, "", fontSize, fontFamily, fontWeight, fontStyle, maxWidth, letterSpacing);
                             if (hyphenated != null)
                             {
                                 lines.Add(hyphenated.Item1);
                                 currentLine = hyphenated.Item2;
-                                currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle);
+                                currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
                             }
                             else if (breakWord)
                             {
-                                var broken = BreakWordByCharacter(currentLine, fontSize, fontFamily, fontWeight, fontStyle, maxWidth);
+                                var broken = BreakWordByCharacter(currentLine, fontSize, fontFamily, fontWeight, fontStyle, maxWidth, letterSpacing);
                                 for (int bi = 0; bi < broken.Count - 1; bi++) lines.Add(broken[bi]);
                                 currentLine = broken.Count > 0 ? broken[broken.Count - 1] : "";
-                                currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle);
+                                currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
                             }
                         }
                         else if (breakWord)
                         {
-                            var broken = BreakWordByCharacter(currentLine, fontSize, fontFamily, fontWeight, fontStyle, maxWidth);
+                            var broken = BreakWordByCharacter(currentLine, fontSize, fontFamily, fontWeight, fontStyle, maxWidth, letterSpacing);
                             for (int bi = 0; bi < broken.Count - 1; bi++) lines.Add(broken[bi]);
                             currentLine = broken.Count > 0 ? broken[broken.Count - 1] : "";
-                            currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle);
+                            currentLineWidth = MeasureWidth(currentLine, fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
                         }
                     }
                 }
@@ -271,7 +344,8 @@ public static class TextMeasurer
     /// hyphenation point. Returns (lineWithHyphen, remainder) or null if no point fits.
     /// </summary>
     private static Tuple<string, string>? HyphenateWordToFit(string word, string linePrefix,
-        float fontSize, string? fontFamily, string? fontWeight, string? fontStyle, float maxWidth)
+        float fontSize, string? fontFamily, string? fontWeight, string? fontStyle, float maxWidth,
+        float letterSpacing = 0f)
     {
         var breakPoints = _englishHyphenator.Hyphenate(word);
         if (breakPoints.Length == 0) return null;
@@ -284,7 +358,7 @@ public static class TextMeasurer
             int bp = breakPoints[k];
             var prefix = word.Substring(0, bp) + "-";
             var candidate = linePrefix + prefix;
-            if (MeasureWidth(candidate, fontSize, fontFamily, fontWeight, fontStyle) <= maxWidth)
+            if (MeasureWidth(candidate, fontSize, fontFamily, fontWeight, fontStyle, letterSpacing) <= maxWidth)
             {
                 bestLine = candidate;
                 bestRemainder = word.Substring(bp);
@@ -298,7 +372,7 @@ public static class TextMeasurer
 
     /// <summary>Break a single word into chunks that each fit within maxWidth.</summary>
     private static List<string> BreakWordByCharacter(string word, float fontSize,
-        string? fontFamily, string? fontWeight, string? fontStyle, float maxWidth)
+        string? fontFamily, string? fontWeight, string? fontStyle, float maxWidth, float letterSpacing = 0f)
     {
         var chunks = new List<string>();
         if (string.IsNullOrEmpty(word))
@@ -313,7 +387,7 @@ public static class TextMeasurer
         float runWidth = 0f;
         for (int i = 0; i < word.Length; i++)
         {
-            float cw = StandardFontMetrics.MeasureCharWidth(word[i], fontSize, pdfFont);
+            float cw = MeasureWidth(word[i].ToString(), fontSize, fontFamily, fontWeight, fontStyle, letterSpacing);
             if (runWidth + cw > maxWidth && i > start)
             {
                 chunks.Add(word.Substring(start, i - start));

--- a/src/EggPdf.Pdf/CmsSignedDataBuilder.cs
+++ b/src/EggPdf.Pdf/CmsSignedDataBuilder.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace EggPdf.Pdf;
+
+/// <summary>
+/// Builds a detached CMS/PKCS#7 SignedData structure (RFC 5652) for PDF
+/// signatures (adbe.pkcs7.detached) using only in-box crypto primitives —
+/// no System.Security.Cryptography.Pkcs package. SHA-256 digest, RSA
+/// PKCS#1 v1.5 signature, signed attributes (content-type, message-digest,
+/// signing-time).
+/// </summary>
+internal static class CmsSignedDataBuilder
+{
+    private const string OidData = "1.2.840.113549.1.7.1";
+    private const string OidSignedData = "1.2.840.113549.1.7.2";
+    private const string OidSha256 = "2.16.840.1.101.3.4.2.1";
+    private const string OidRsa = "1.2.840.113549.1.1.1";
+    private const string OidContentType = "1.2.840.113549.1.9.3";
+    private const string OidMessageDigest = "1.2.840.113549.1.9.4";
+    private const string OidSigningTime = "1.2.840.113549.1.9.5";
+
+    /// <summary>
+    /// Build a detached SignedData over content whose SHA-256 digest is given.
+    /// </summary>
+    public static byte[] BuildDetached(byte[] contentDigestSha256, X509Certificate2 certificate, DateTime signingTimeUtc)
+    {
+        var rsa = certificate.GetRSAPrivateKey();
+        if (rsa == null)
+            throw new InvalidOperationException("The certificate has no RSA private key.");
+
+        using (rsa)
+        {
+            // Signed attributes (DER SET OF, sorted by encoding)
+            var attrContentType = Sequence(Oid(OidContentType), SetOf(Oid(OidData)));
+            var attrSigningTime = Sequence(Oid(OidSigningTime), SetOf(UtcTime(signingTimeUtc)));
+            var attrMessageDigest = Sequence(Oid(OidMessageDigest), SetOf(OctetString(contentDigestSha256)));
+            var signedAttrsSet = SetOfSorted(attrContentType, attrSigningTime, attrMessageDigest);
+
+            // The signature covers the DER SET OF (tag 0x31) encoding of the attributes
+            byte[] attrsDigest;
+            using (var sha = SHA256.Create())
+                attrsDigest = sha.ComputeHash(signedAttrsSet);
+            var signature = rsa.SignHash(attrsDigest, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+            var digestAlg = Sequence(Oid(OidSha256), Null());
+            var sigAlg = Sequence(Oid(OidRsa), Null());
+
+            var issuerAndSerial = Sequence(
+                Raw(certificate.IssuerName.RawData),
+                IntegerFromSerial(certificate.GetSerialNumber()));
+
+            var signerInfo = Sequence(
+                Integer(1),
+                issuerAndSerial,
+                digestAlg,
+                Retag(signedAttrsSet, 0xA0), // [0] IMPLICIT SignedAttributes
+                sigAlg,
+                OctetString(signature));
+
+            var signedData = Sequence(
+                Integer(1),
+                SetOf(digestAlg),
+                Sequence(Oid(OidData)),                      // detached: no eContent
+                Retag(SetOf(Raw(certificate.RawData)), 0xA0), // [0] IMPLICIT CertificateSet
+                SetOf(signerInfo));
+
+            // ContentInfo { signedData OID, [0] EXPLICIT SignedData }
+            return Sequence(Oid(OidSignedData), Tlv(0xA0, signedData));
+        }
+    }
+
+    // ===== Minimal DER encoding helpers =====
+
+    private static byte[] Tlv(byte tag, byte[] content)
+    {
+        byte[] lenBytes;
+        int len = content.Length;
+        if (len < 0x80)
+            lenBytes = new[] { (byte)len };
+        else if (len <= 0xFF)
+            lenBytes = new byte[] { 0x81, (byte)len };
+        else if (len <= 0xFFFF)
+            lenBytes = new byte[] { 0x82, (byte)(len >> 8), (byte)len };
+        else
+            lenBytes = new byte[] { 0x83, (byte)(len >> 16), (byte)(len >> 8), (byte)len };
+
+        var result = new byte[1 + lenBytes.Length + len];
+        result[0] = tag;
+        Array.Copy(lenBytes, 0, result, 1, lenBytes.Length);
+        Array.Copy(content, 0, result, 1 + lenBytes.Length, len);
+        return result;
+    }
+
+    private static byte[] Concat(byte[][] parts)
+    {
+        int total = 0;
+        foreach (var p in parts) total += p.Length;
+        var result = new byte[total];
+        int pos = 0;
+        foreach (var p in parts)
+        {
+            Array.Copy(p, 0, result, pos, p.Length);
+            pos += p.Length;
+        }
+        return result;
+    }
+
+    private static byte[] Sequence(params byte[][] parts) => Tlv(0x30, Concat(parts));
+
+    private static byte[] SetOf(params byte[][] parts) => Tlv(0x31, Concat(parts));
+
+    /// <summary>DER SET OF requires elements sorted by their encoded bytes.</summary>
+    private static byte[] SetOfSorted(params byte[][] parts)
+    {
+        var list = new List<byte[]>(parts);
+        list.Sort(CompareDer);
+        return SetOf(list.ToArray());
+    }
+
+    private static int CompareDer(byte[] a, byte[] b)
+    {
+        int n = Math.Min(a.Length, b.Length);
+        for (int i = 0; i < n; i++)
+        {
+            int c = a[i].CompareTo(b[i]);
+            if (c != 0) return c;
+        }
+        return a.Length.CompareTo(b.Length);
+    }
+
+    private static byte[] Oid(string dotted)
+    {
+        var parts = dotted.Split('.');
+        var body = new List<byte>();
+        body.Add((byte)(int.Parse(parts[0]) * 40 + int.Parse(parts[1])));
+        for (int i = 2; i < parts.Length; i++)
+        {
+            long v = long.Parse(parts[i]);
+            var chunk = new List<byte>();
+            do
+            {
+                chunk.Insert(0, (byte)(v & 0x7F));
+                v >>= 7;
+            } while (v > 0);
+            for (int c = 0; c < chunk.Count - 1; c++)
+                chunk[c] |= 0x80;
+            body.AddRange(chunk);
+        }
+        return Tlv(0x06, body.ToArray());
+    }
+
+    private static byte[] Integer(int value)
+    {
+        if (value >= 0 && value < 0x80)
+            return new byte[] { 0x02, 0x01, (byte)value };
+        var bytes = new List<byte>();
+        uint v = (uint)value;
+        while (v > 0) { bytes.Insert(0, (byte)(v & 0xFF)); v >>= 8; }
+        if (bytes.Count == 0) bytes.Add(0);
+        if ((bytes[0] & 0x80) != 0) bytes.Insert(0, 0);
+        return Tlv(0x02, bytes.ToArray());
+    }
+
+    /// <summary>X509Certificate2.GetSerialNumber() returns little-endian bytes.</summary>
+    private static byte[] IntegerFromSerial(byte[] littleEndianSerial)
+    {
+        var big = (byte[])littleEndianSerial.Clone();
+        Array.Reverse(big);
+        int skip = 0;
+        while (skip < big.Length - 1 && big[skip] == 0 && (big[skip + 1] & 0x80) == 0)
+            skip++;
+        var trimmed = new byte[big.Length - skip];
+        Array.Copy(big, skip, trimmed, 0, trimmed.Length);
+        if ((trimmed[0] & 0x80) != 0)
+        {
+            var padded = new byte[trimmed.Length + 1];
+            Array.Copy(trimmed, 0, padded, 1, trimmed.Length);
+            trimmed = padded;
+        }
+        return Tlv(0x02, trimmed);
+    }
+
+    private static byte[] OctetString(byte[] data) => Tlv(0x04, data);
+
+    private static byte[] Null() => new byte[] { 0x05, 0x00 };
+
+    private static byte[] UtcTime(DateTime utc) =>
+        Tlv(0x17, Encoding.ASCII.GetBytes(utc.ToString("yyMMddHHmmss") + "Z"));
+
+    private static byte[] Raw(byte[] der) => der;
+
+    /// <summary>Replace an encoding's tag byte (IMPLICIT context tagging).</summary>
+    private static byte[] Retag(byte[] tlv, byte newTag)
+    {
+        var result = (byte[])tlv.Clone();
+        result[0] = newTag;
+        return result;
+    }
+}

--- a/src/EggPdf.Pdf/PdfDocument.cs
+++ b/src/EggPdf.Pdf/PdfDocument.cs
@@ -263,14 +263,7 @@ public class PdfDocument
             var img = _images[kv.Key];
             var smaskData = img.SMaskData!;
 
-            // Compress with Deflate
-            byte[] compressedSmask;
-            using (var sms = new MemoryStream())
-            {
-                using (var ds = new DeflateStream(sms, CompressionLevel.Fastest, true))
-                    ds.Write(smaskData, 0, smaskData.Length);
-                compressedSmask = sms.ToArray();
-            }
+            byte[] compressedSmask = CompressZlib(smaskData);
 
             offsets[kv.Value] = writer.Position;
             writer.WriteLine($"{kv.Value} 0 obj");
@@ -307,14 +300,8 @@ public class PdfDocument
             }
             else
             {
-                // Raw RGB: compress with Deflate
-                byte[] compressed;
-                using (var ims = new MemoryStream())
-                {
-                    using (var ds = new DeflateStream(ims, CompressionLevel.Fastest, true))
-                        ds.Write(img.Data, 0, img.Data.Length);
-                    compressed = ims.ToArray();
-                }
+                // Raw RGB: compress with zlib (FlateDecode)
+                byte[] compressed = CompressZlib(img.Data);
 
                 var imgDict = new StringBuilder();
                 imgDict.Append($"<< /Type /XObject /Subtype /Image /Width {img.Width} /Height {img.Height}");
@@ -662,19 +649,42 @@ public class PdfDocument
         return total;
     }
 
+    /// <summary>
+    /// Compress data as a zlib stream (RFC 1950) for /FlateDecode: 2-byte header,
+    /// raw deflate body, Adler-32 checksum. DeflateStream alone emits raw deflate
+    /// (RFC 1951), which strict PDF viewers reject.
+    /// </summary>
+    private static byte[] CompressZlib(byte[] data)
+    {
+        using var ms = new MemoryStream();
+        ms.WriteByte(0x78); // CMF: deflate, 32K window
+        ms.WriteByte(0x9C); // FLG: default compression, FCHECK valid
+        using (var ds = new DeflateStream(ms, CompressionLevel.Fastest, true))
+            ds.Write(data, 0, data.Length);
+
+        // Adler-32 of the uncompressed data (big-endian)
+        uint a = 1, b = 0;
+        for (int i = 0; i < data.Length; i++)
+        {
+            a = (a + data[i]) % 65521;
+            b = (b + a) % 65521;
+        }
+        uint adler = (b << 16) | a;
+        ms.WriteByte((byte)(adler >> 24));
+        ms.WriteByte((byte)(adler >> 16));
+        ms.WriteByte((byte)(adler >> 8));
+        ms.WriteByte((byte)adler);
+
+        return ms.ToArray();
+    }
+
     /// <summary>Write a CIDFont Type 2 (embedded TrueType) with all required objects.</summary>
     private void WriteCIDFont(PdfStreamWriter writer, Dictionary<int, long> offsets,
         string fontName, (int type0, int cidFont, int descriptor, int stream, int toUnicode) objs,
         EmbeddedFontData fontData)
     {
         // 1. Compress the subset font data
-        byte[] compressed;
-        using (var ms = new MemoryStream())
-        {
-            using (var ds = new DeflateStream(ms, CompressionLevel.Fastest, true))
-                ds.Write(fontData.SubsetData, 0, fontData.SubsetData.Length);
-            compressed = ms.ToArray();
-        }
+        byte[] compressed = CompressZlib(fontData.SubsetData);
 
         // 2. Build W (widths) array: /W [0 [w0 w1 w2 ...]]
         var wArray = new StringBuilder();
@@ -691,13 +701,7 @@ public class PdfDocument
         // 3. Build ToUnicode CMap
         byte[] toUnicodeData = BuildToUnicodeCMap(fontData.CodepointToGlyphId);
 
-        byte[] toUnicodeCompressed;
-        using (var ms = new MemoryStream())
-        {
-            using (var ds = new DeflateStream(ms, CompressionLevel.Fastest, true))
-                ds.Write(toUnicodeData, 0, toUnicodeData.Length);
-            toUnicodeCompressed = ms.ToArray();
-        }
+        byte[] toUnicodeCompressed = CompressZlib(toUnicodeData);
 
         // 4. Write font stream (subset TrueType data)
         offsets[objs.stream] = writer.Position;

--- a/src/EggPdf.Pdf/PdfDocument.cs
+++ b/src/EggPdf.Pdf/PdfDocument.cs
@@ -44,6 +44,14 @@ public class PdfDocument
     public bool IsEmbeddedFont(string fontName) => _embeddedFonts.ContainsKey(fontName);
 
     /// <summary>Convert text to glyph IDs for an embedded CIDFont.</summary>
+    /// <summary>Look up a single codepoint's glyph ID in an embedded font.</summary>
+    public bool TryGetGlyphId(string fontName, int codepoint, out ushort gid)
+    {
+        gid = 0;
+        return _embeddedFonts.TryGetValue(fontName, out var fontData) &&
+               fontData.CodepointToGlyphId.TryGetValue(codepoint, out gid);
+    }
+
     public ushort[]? GetGlyphIds(string fontName, string text)
     {
         if (!_embeddedFonts.TryGetValue(fontName, out var fontData))

--- a/src/EggPdf.Pdf/PdfPage.cs
+++ b/src/EggPdf.Pdf/PdfPage.cs
@@ -316,7 +316,10 @@ public class PdfPage
     /// <summary>Set fill and stroke opacity (0.0-1.0). Creates an ExtGState reference.</summary>
     public void SetOpacity(float opacity)
     {
-        if (opacity >= 1.0f) return; // fully opaque, no ExtGState needed
+        // SetOpacity(1) must EMIT a reset state — the gs operator persists, so
+        // silently skipping it leaks the previous alpha into later content.
+        if (opacity > 1.0f) opacity = 1.0f;
+        if (opacity < 0f) opacity = 0f;
         var gsName = $"GS{(int)(opacity * 100)}";
         UsedExtGStates.Add(gsName);
         ContentStream.AppendLine($"/{gsName} gs");

--- a/src/EggPdf.Pdf/PdfPage.cs
+++ b/src/EggPdf.Pdf/PdfPage.cs
@@ -58,6 +58,34 @@ public class PdfPage
         ContentStream.AppendLine("ET");
     }
 
+    /// <summary>
+    /// Add CID text composed of runs in different embedded fonts (glyph
+    /// fallback). All runs share one BT block; Tj advances the text position,
+    /// so runs flow naturally after each other.
+    /// </summary>
+    public void AddTextRunsCID(List<(string fontName, ushort[] glyphIds)> runs,
+        float x, float y, float fontSize,
+        float colorR = 0, float colorG = 0, float colorB = 0,
+        float letterSpacing = 0, float wordSpacing = 0)
+    {
+        ContentStream.AppendLine($"{F(colorR)} {F(colorG)} {F(colorB)} rg");
+        ContentStream.Append("BT ");
+        ContentStream.Append($"{F(letterSpacing)} Tc ");
+        ContentStream.Append($"{F(wordSpacing)} Tw ");
+        ContentStream.Append($"{F(x)} {F(y)} Td ");
+        foreach (var run in runs)
+        {
+            if (run.glyphIds.Length == 0) continue;
+            UsedFonts.Add(run.fontName);
+            ContentStream.Append($"/{run.fontName} {F(fontSize)} Tf ");
+            ContentStream.Append('<');
+            foreach (var gid in run.glyphIds)
+                ContentStream.Append(gid.ToString("X4"));
+            ContentStream.Append("> Tj ");
+        }
+        ContentStream.AppendLine("ET");
+    }
+
     /// <summary>Append raw PDF content stream commands (for SVG rendering etc.).</summary>
     public void AppendRawContent(string commands)
     {

--- a/src/EggPdf.Pdf/PdfSigner.cs
+++ b/src/EggPdf.Pdf/PdfSigner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 namespace EggPdf.Pdf;
@@ -21,6 +22,84 @@ public static class PdfSigner
         public string? Location { get; set; }
         /// <summary>Signer name.</summary>
         public string? Name { get; set; }
+    }
+
+    private const int ContentsHexLength = 16384;
+
+    /// <summary>
+    /// Sign a PDF in one call with an X.509 certificate (RSA private key).
+    /// Embeds a detached CMS/PKCS#7 signature (adbe.pkcs7.detached) with a
+    /// correct /ByteRange, verifiable by standard PDF/CMS validators.
+    /// </summary>
+    public static byte[] Sign(byte[] pdfBytes, X509Certificate2 certificate, SignOptions? options = null)
+    {
+        if (pdfBytes == null || pdfBytes.Length == 0) return Array.Empty<byte>();
+        if (certificate == null) throw new ArgumentNullException(nameof(certificate));
+
+        options ??= new SignOptions();
+        string name = options.Name
+            ?? certificate.GetNameInfo(X509NameType.SimpleName, false)
+            ?? "Signer";
+
+        // 1. Append the signature dictionary as an incremental update, with a
+        //    fixed-width ByteRange placeholder patched after assembly.
+        const string byteRangePlaceholder = "[0 0000000000 0000000000 0000000000]";
+        var sb = new StringBuilder();
+        sb.AppendLine();
+        int sigValObj = FindNextObjNumber(pdfBytes) + 1;
+        sb.AppendLine($"{sigValObj} 0 obj");
+        sb.Append("<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /adbe.pkcs7.detached");
+        sb.Append($" /Name ({EscapePdf(name)})");
+        if (!string.IsNullOrEmpty(options.Reason))
+            sb.Append($" /Reason ({EscapePdf(options.Reason!)})");
+        if (!string.IsNullOrEmpty(options.Location))
+            sb.Append($" /Location ({EscapePdf(options.Location!)})");
+        sb.Append($" /M (D:{DateTime.UtcNow:yyyyMMddHHmmss}Z)");
+        sb.Append($" /ByteRange {byteRangePlaceholder}");
+        sb.Append($" /Contents <{new string('0', ContentsHexLength)}>");
+        sb.AppendLine(" >>");
+        sb.AppendLine("endobj");
+
+        byte[] output;
+        using (var ms = new MemoryStream())
+        {
+            ms.Write(pdfBytes, 0, pdfBytes.Length);
+            var append = Encoding.ASCII.GetBytes(sb.ToString());
+            ms.Write(append, 0, append.Length);
+            output = ms.ToArray();
+        }
+
+        // 2. Locate the Contents hex gap and patch the real ByteRange
+        var text = Encoding.ASCII.GetString(output, pdfBytes.Length, output.Length - pdfBytes.Length);
+        int hexInAppend = text.IndexOf(new string('0', ContentsHexLength), StringComparison.Ordinal);
+        int hexStart = pdfBytes.Length + hexInAppend;
+        int gapStart = hexStart - 1;                     // the '<'
+        int gapEnd = hexStart + ContentsHexLength + 1;   // after the '>'
+        int tailLength = output.Length - gapEnd;
+
+        string byteRange = $"[0 {gapStart:D10} {gapEnd:D10} {tailLength:D10}]";
+        int brInAppend = text.IndexOf(byteRangePlaceholder, StringComparison.Ordinal);
+        var brBytes = Encoding.ASCII.GetBytes(byteRange);
+        Array.Copy(brBytes, 0, output, pdfBytes.Length + brInAppend, brBytes.Length);
+
+        // 3. Hash the two byte ranges and build the detached CMS signature
+        byte[] digest;
+        using (var sha = SHA256.Create())
+        {
+            sha.TransformBlock(output, 0, gapStart, null, 0);
+            sha.TransformFinalBlock(output, gapEnd, tailLength);
+            digest = sha.Hash!;
+        }
+
+        var cms = CmsSignedDataBuilder.BuildDetached(digest, certificate, DateTime.UtcNow);
+        if (cms.Length * 2 > ContentsHexLength)
+            throw new InvalidOperationException("CMS signature exceeds the reserved /Contents space.");
+
+        // 4. Write the CMS hex into the reserved gap
+        var cmsHex = Encoding.ASCII.GetBytes(BitConverter.ToString(cms).Replace("-", ""));
+        Array.Copy(cmsHex, 0, output, hexStart, cmsHex.Length);
+
+        return output;
     }
 
     /// <summary>

--- a/src/EggPdf.Pdf/PngDecoder.cs
+++ b/src/EggPdf.Pdf/PngDecoder.cs
@@ -74,8 +74,10 @@ internal static class PngDecoder
         // Only 8-bit and 16-bit depth
         if (bitDepth != 8 && bitDepth != 16)
         {
-            // For indexed (color type 3), also allow 1, 2, 4 bit depth
-            if (colorType == 3 && (bitDepth == 1 || bitDepth == 2 || bitDepth == 4))
+            // Indexed (color type 3) and grayscale (color type 0) also allow
+            // 1, 2, 4 bit depth — 1-bit grayscale is the common QR code format.
+            if ((colorType == 3 || colorType == 0) &&
+                (bitDepth == 1 || bitDepth == 2 || bitDepth == 4))
             {
                 // OK
             }
@@ -155,6 +157,39 @@ internal static class PngDecoder
         return ConvertPixels(unfiltered, width, height, bitDepth, colorType, channels, stride, palette, trns);
     }
 
+    /// <summary>Extract a grayscale sample for bit depths 1, 2, 4, or 8.</summary>
+    private static int GetGraySample(byte[] data, int rowOffset, int x, int bitDepth)
+    {
+        switch (bitDepth)
+        {
+            case 1:
+            {
+                byte b = data[rowOffset + (x >> 3)];
+                return (b >> (7 - (x & 7))) & 0x1;
+            }
+            case 2:
+            {
+                byte b = data[rowOffset + (x >> 2)];
+                return (b >> (6 - ((x & 3) << 1))) & 0x3;
+            }
+            case 4:
+            {
+                byte b = data[rowOffset + (x >> 1)];
+                return (x & 1) == 0 ? (b >> 4) & 0xF : b & 0xF;
+            }
+            default:
+                return data[rowOffset + x];
+        }
+    }
+
+    /// <summary>Scale a sub-byte grayscale sample to the full 0-255 range.</summary>
+    private static byte ScaleGraySample(int sample, int bitDepth)
+    {
+        if (bitDepth >= 8) return (byte)sample;
+        int maxVal = (1 << bitDepth) - 1;
+        return (byte)(sample * 255 / maxVal);
+    }
+
     private static PngDecodeResult? ConvertPixels(byte[] unfiltered, int width, int height,
         int bitDepth, int colorType, int channels, int stride, byte[]? palette, byte[]? trns)
     {
@@ -188,12 +223,13 @@ internal static class PngDecoder
                             }
                             else
                             {
-                                gray = unfiltered[srcRow + x];
+                                int sample = GetGraySample(unfiltered, srcRow, x, bitDepth);
+                                gray = ScaleGraySample(sample, bitDepth);
                                 int dstIdx = (y * width + x) * 4;
                                 rgba[dstIdx] = (byte)gray;
                                 rgba[dstIdx + 1] = (byte)gray;
                                 rgba[dstIdx + 2] = (byte)gray;
-                                rgba[dstIdx + 3] = (byte)(gray == trnsGray ? 0 : 255);
+                                rgba[dstIdx + 3] = (byte)(sample == trnsGray ? 0 : 255);
                             }
                         }
                     }
@@ -211,7 +247,7 @@ internal static class PngDecoder
                             if (bitDepth == 16)
                                 gray = unfiltered[srcRow + x * 2]; // take high byte
                             else
-                                gray = unfiltered[srcRow + x];
+                                gray = (byte)ScaleGraySample(GetGraySample(unfiltered, srcRow, x, bitDepth), bitDepth);
 
                             int dstIdx = (y * width + x) * 3;
                             rgb[dstIdx] = gray;

--- a/src/EggPdf.Text/FontResolver.cs
+++ b/src/EggPdf.Text/FontResolver.cs
@@ -27,11 +27,11 @@ public class FontResolver
         // Try variant names first (e.g., Arial Bold, Arial Italic)
         string[] candidates;
         if (bold && italic)
-            candidates = new[] { familyName + "BoldItalic", familyName + "-BoldItalic", familyName + "BI" };
+            candidates = new[] { familyName + " Bold Italic", familyName + "BoldItalic", familyName + "-BoldItalic", familyName + "bi", familyName + "BI" };
         else if (bold)
-            candidates = new[] { familyName + "Bold", familyName + "-Bold", familyName + "bd" };
+            candidates = new[] { familyName + " Bold", familyName + "Bold", familyName + "-Bold", familyName + "bd" };
         else if (italic)
-            candidates = new[] { familyName + "Italic", familyName + "-Italic", familyName + "it" };
+            candidates = new[] { familyName + " Italic", familyName + "Italic", familyName + "-Italic", familyName + "it" };
         else
             candidates = new[] { familyName };
 

--- a/src/EggPdf.Text/FontUrlFetcher.cs
+++ b/src/EggPdf.Text/FontUrlFetcher.cs
@@ -86,11 +86,11 @@ public static class FontUrlFetcher
 
         var trimmed = srcValue.Trim();
 
-        // url("...") or url('...') or url(...)
+        // url("...") or url('...') or url(...), possibly followed by format(...)
         if (trimmed.StartsWith("url(", StringComparison.OrdinalIgnoreCase))
         {
             int start = 4;
-            int end = trimmed.Length - 1;
+            int end = trimmed.IndexOf(')', start); // stop at the url() token, not the string end
             if (end <= start) return null;
 
             var url = trimmed.Substring(start, end - start).Trim();
@@ -99,17 +99,17 @@ public static class FontUrlFetcher
                 (url[0] == '\'' && url[url.Length - 1] == '\'')))
                 url = url.Substring(1, url.Length - 2);
 
-            return url;
+            return url.Length > 0 ? url : null;
         }
 
         // local("FontName") — return as-is for system font resolution
         if (trimmed.StartsWith("local(", StringComparison.OrdinalIgnoreCase))
         {
             int start = 6;
-            int end = trimmed.Length - 1;
+            int end = trimmed.IndexOf(')', start);
             if (end <= start) return null;
             var name = trimmed.Substring(start, end - start).Trim().Trim('"', '\'');
-            return "local:" + name;
+            return name.Length > 0 ? "local:" + name : null;
         }
 
         return null;

--- a/src/EggPdf.Text/FontUrlFetcher.cs
+++ b/src/EggPdf.Text/FontUrlFetcher.cs
@@ -112,6 +112,15 @@ public static class FontUrlFetcher
             return name.Length > 0 ? "local:" + name : null;
         }
 
+        // Bare URL: CSS parsers may already unwrap url(...), leaving
+        // "https://... format('truetype')" — take the first token.
+        int ws = trimmed.IndexOfAny(new[] { ' ', '\t' });
+        var bare = (ws > 0 ? trimmed.Substring(0, ws) : trimmed).Trim('"', '\'');
+        if (bare.Length > 0 &&
+            !bare.StartsWith("format(", StringComparison.OrdinalIgnoreCase) &&
+            !bare.StartsWith("tech(", StringComparison.OrdinalIgnoreCase))
+            return bare;
+
         return null;
     }
 

--- a/src/EggPdf.Text/SystemFontLocator.cs
+++ b/src/EggPdf.Text/SystemFontLocator.cs
@@ -56,22 +56,57 @@ public static class SystemFontLocator
         if (resolved != familyName)
             familyName = resolved;
 
+        var spaceless = familyName.Replace(" ", "");
+
+        // Rank matches so exact names win over substrings ("Arial.ttf" over
+        // "Arial Black.ttf") and spaceless forms match ("Segoe UI" -> segoeui.ttf).
+        string? best = null;
+        int bestRank = int.MaxValue;
+        int bestLength = int.MaxValue;
+
         foreach (var dir in GetFontDirectories())
         {
             try
             {
-                var files = Directory.GetFiles(dir, "*.ttf", SearchOption.AllDirectories);
-                var match = files.FirstOrDefault(f =>
-                    Path.GetFileNameWithoutExtension(f)
-                        .IndexOf(familyName, StringComparison.OrdinalIgnoreCase) >= 0);
-                if (match != null) return match;
+                var files = Directory.GetFiles(dir, "*.ttf", SearchOption.AllDirectories)
+                    .Concat(Directory.GetFiles(dir, "*.otf", SearchOption.AllDirectories));
 
-                // Also check .otf
-                var otfFiles = Directory.GetFiles(dir, "*.otf", SearchOption.AllDirectories);
-                match = otfFiles.FirstOrDefault(f =>
-                    Path.GetFileNameWithoutExtension(f)
-                        .IndexOf(familyName, StringComparison.OrdinalIgnoreCase) >= 0);
-                if (match != null) return match;
+                foreach (var file in files)
+                {
+                    var name = Path.GetFileNameWithoutExtension(file);
+                    var nameSpaceless = name.Replace(" ", "").Replace("-", "");
+
+                    int rank;
+                    if (string.Equals(name, familyName, StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(nameSpaceless, spaceless, StringComparison.OrdinalIgnoreCase))
+                        rank = 0;
+                    else if (name.IndexOf(familyName, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                             nameSpaceless.IndexOf(spaceless, StringComparison.OrdinalIgnoreCase) >= 0)
+                        rank = 1;
+                    else
+                        continue;
+
+                    // Demote variant files (Bold/Italic) the query didn't ask for,
+                    // so "LiberationSans" finds Regular, not Bold.
+                    if (name.IndexOf("bold", StringComparison.OrdinalIgnoreCase) >= 0 &&
+                        familyName.IndexOf("bold", StringComparison.OrdinalIgnoreCase) < 0 &&
+                        familyName.IndexOf("bd", StringComparison.OrdinalIgnoreCase) < 0)
+                        rank += 10;
+                    if ((name.IndexOf("italic", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                         name.IndexOf("oblique", StringComparison.OrdinalIgnoreCase) >= 0) &&
+                        familyName.IndexOf("italic", StringComparison.OrdinalIgnoreCase) < 0 &&
+                        familyName.IndexOf("oblique", StringComparison.OrdinalIgnoreCase) < 0 &&
+                        familyName.IndexOf("it", StringComparison.OrdinalIgnoreCase) < 0)
+                        rank += 10;
+
+                    if (rank < bestRank || (rank == bestRank && name.Length < bestLength))
+                    {
+                        best = file;
+                        bestRank = rank;
+                        bestLength = name.Length;
+                        if (rank == 0 && name.Length == familyName.Length) return best;
+                    }
+                }
             }
             catch
             {
@@ -79,7 +114,7 @@ public static class SystemFontLocator
             }
         }
 
-        return null;
+        return best;
     }
 
     /// <summary>Map generic CSS family names to platform-specific font names.</summary>
@@ -94,7 +129,7 @@ public static class SystemFontLocator
                 "monospace" => "Consolas",
                 "cursive" => "Comic Sans MS",
                 "fantasy" => "Impact",
-                _ => "Arial"
+                _ => genericName
             };
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -106,7 +141,7 @@ public static class SystemFontLocator
                 "monospace" => "Menlo",
                 "cursive" => "Apple Chancery",
                 "fantasy" => "Papyrus",
-                _ => "Helvetica"
+                _ => genericName
             };
         }
         else // Linux
@@ -118,7 +153,7 @@ public static class SystemFontLocator
                 "monospace" => "DejaVuSansMono",
                 "cursive" => "DejaVuSans",
                 "fantasy" => "DejaVuSans",
-                _ => "DejaVuSans"
+                _ => genericName
             };
         }
     }

--- a/src/EggPdf.Text/TrueType/TtfParser.cs
+++ b/src/EggPdf.Text/TrueType/TtfParser.cs
@@ -144,29 +144,62 @@ public static class TtfParser
 
         ushort numSubtables = ReadUInt16(data, ref pos);
 
-        // Find a Unicode subtable (platformID 0 or 3)
-        int bestOffset = -1;
+        // Find Unicode subtables (platformID 0 or 3). A font may expose several;
+        // prefer format 12 (full Unicode) over format 4 (BMP only).
+        int format4Offset = -1;
+        int format12Offset = -1;
         for (int i = 0; i < numSubtables; i++)
         {
             ushort platformID = ReadUInt16(data, ref pos);
             ushort encodingID = ReadUInt16(data, ref pos);
             uint subtableOffset = ReadUInt32(data, ref pos);
 
-            if (platformID == 0 || (platformID == 3 && (encodingID == 1 || encodingID == 10)))
-            {
-                bestOffset = offset + (int)subtableOffset;
-            }
+            if (platformID != 0 && !(platformID == 3 && (encodingID == 1 || encodingID == 10)))
+                continue;
+
+            int subStart = offset + (int)subtableOffset;
+            if (subStart + 2 > data.Length) continue;
+
+            int subPos = subStart;
+            ushort format = ReadUInt16(data, ref subPos);
+            if (format == 4 && format4Offset < 0)
+                format4Offset = subStart;
+            else if (format == 12 && format12Offset < 0)
+                format12Offset = subStart;
         }
 
-        if (bestOffset < 0) return;
+        if (format12Offset >= 0)
+            ParseCmapFormat12(data, format12Offset, font.Cmap);
+        else if (format4Offset >= 0)
+            ParseCmapFormat4(data, format4Offset, font.Cmap);
+    }
 
-        // Read subtable format
-        int subPos = bestOffset;
-        ushort format = ReadUInt16(data, ref subPos);
+    private static void ParseCmapFormat12(byte[] data, int offset, CmapData cmap)
+    {
+        int pos = offset + 4; // skip format (2) + reserved (2)
+        pos += 4; // length
+        pos += 4; // language
+        uint numGroups = ReadUInt32(data, ref pos);
 
-        if (format == 4)
-            ParseCmapFormat4(data, bestOffset, font.Cmap);
-        // Format 12 support can be added later for supplementary planes
+        const int MaxMappings = 500000; // safety cap against corrupt group counts
+        int added = 0;
+        for (uint g = 0; g < numGroups; g++)
+        {
+            if (pos + 12 > data.Length) return;
+            uint startChar = ReadUInt32(data, ref pos);
+            uint endChar = ReadUInt32(data, ref pos);
+            uint startGlyph = ReadUInt32(data, ref pos);
+
+            if (endChar < startChar || endChar > 0x10FFFF) continue;
+
+            for (uint cp = startChar; cp <= endChar; cp++)
+            {
+                ushort glyphId = (ushort)(startGlyph + (cp - startChar));
+                if (glyphId != 0)
+                    cmap.Add((int)cp, glyphId);
+                if (++added >= MaxMappings) return;
+            }
+        }
     }
 
     private static void ParseCmapFormat4(byte[] data, int offset, CmapData cmap)

--- a/src/EggPdf.Text/TrueType/TtfSubsetter.cs
+++ b/src/EggPdf.Text/TrueType/TtfSubsetter.cs
@@ -388,21 +388,27 @@ public class TtfSubsetter
 
     private static void WriteFormat4(BinaryWriter bw, Dictionary<int, ushort> cpToGid)
     {
-        // Sort codepoints into segments of contiguous ranges
-        int[] sortedKeys = GetSortedKeys(cpToGid, bmp: true);
-        int[] sorted = sortedKeys.Length == 0 ? new[] { 0 } : sortedKeys;
+        // Sort codepoints into segments. Because only idDelta mapping is written
+        // (no glyphIdArray), a segment must be contiguous in BOTH codepoints and
+        // glyph IDs, so break whenever either sequence jumps.
+        int[] sorted = GetSortedKeys(cpToGid, bmp: true);
 
         var segments = new List<(ushort startCode, ushort endCode, short idDelta)>();
-        int segStart = 0;
-        for (int i = 0; i <= sorted.Length; i++)
+        if (sorted.Length > 0)
         {
-            if (i == sorted.Length || (i > segStart && sorted[i] != sorted[i - 1] + 1))
+            int segStart = 0;
+            for (int i = 1; i <= sorted.Length; i++)
             {
-                ushort sc = (ushort)sorted[segStart];
-                ushort ec = (ushort)sorted[i - 1];
-                short delta = (short)(cpToGid[sorted[segStart]] - sc);
-                segments.Add((sc, ec, delta));
-                segStart = i;
+                if (i == sorted.Length ||
+                    sorted[i] != sorted[i - 1] + 1 ||
+                    cpToGid[sorted[i]] != cpToGid[sorted[i - 1]] + 1)
+                {
+                    ushort sc = (ushort)sorted[segStart];
+                    ushort ec = (ushort)sorted[i - 1];
+                    short delta = (short)(cpToGid[sorted[segStart]] - sc);
+                    segments.Add((sc, ec, delta));
+                    segStart = i;
+                }
             }
         }
         // Add sentinel segment

--- a/src/EggPdf/EggPdf.csproj
+++ b/src/EggPdf/EggPdf.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>EggPdf</RootNamespace>
-    <Version>1.3.6</Version>
+    <Version>1.4.0</Version>
     <IsPackable>true</IsPackable>
 
     <!-- NuGet package metadata (shared metadata is in Directory.Build.props) -->

--- a/src/EggPdf/HtmlToPdf.cs
+++ b/src/EggPdf/HtmlToPdf.cs
@@ -69,6 +69,11 @@ public static class HtmlToPdf
         // 1. Parse HTML -> DOM
         var document = HtmlParser.Parse(html);
 
+        // 1b. Decode Cloudflare email obfuscation (browsers do this via script,
+        // which a PDF engine does not run).
+        if (document.Body != null)
+            DecodeCloudflareEmails(document.Body);
+
         // 2. Extract <style> tags, <link> stylesheets, and resolve @imports
         var stylesheets = ExtractStyleSheets(document, basePath);
 
@@ -128,6 +133,49 @@ public static class HtmlToPdf
         finally
         {
             TextMeasurer.FontDataProvider = null;
+        }
+    }
+
+    /// <summary>
+    /// Decode Cloudflare-obfuscated emails: data-cfemail holds hex bytes where
+    /// the first byte is an XOR key for the rest. The placeholder child text
+    /// ("[email protected]") is replaced with the decoded address.
+    /// </summary>
+    private static void DecodeCloudflareEmails(HtmlElement element)
+    {
+        var cf = element.GetAttribute("data-cfemail");
+        if (!string.IsNullOrEmpty(cf) && cf!.Length >= 4 && cf.Length % 2 == 0)
+        {
+            var email = TryDecodeCfEmail(cf);
+            if (email != null)
+            {
+                element.ChildNodes.Clear();
+                element.ChildNodes.Add(new HtmlTextNode(email));
+                return;
+            }
+        }
+
+        foreach (var child in element.ChildNodes)
+        {
+            if (child is HtmlElement childElem)
+                DecodeCloudflareEmails(childElem);
+        }
+    }
+
+    private static string? TryDecodeCfEmail(string hex)
+    {
+        try
+        {
+            int key = Convert.ToInt32(hex.Substring(0, 2), 16);
+            var sb = new StringBuilder((hex.Length - 2) / 2);
+            for (int i = 2; i < hex.Length; i += 2)
+                sb.Append((char)(Convert.ToInt32(hex.Substring(i, 2), 16) ^ key));
+            var email = sb.ToString();
+            return email.IndexOf('@') > 0 ? email : null;
+        }
+        catch
+        {
+            return null; // malformed hex — leave the placeholder text as-is
         }
     }
 
@@ -550,6 +598,57 @@ public static class HtmlToPdf
                 fontData.UnitsPerEm,
                 fontData.Ascent,
                 fontData.Descent);
+
+            // Codepoints the chosen font cannot shape (e.g. ⚠ in text fonts):
+            // embed a symbol-capable fallback the renderer can switch to mid-run.
+            HashSet<int>? missing = null;
+            foreach (var cp in codepoints)
+            {
+                if (cp > 0x20 && fontData.GetGlyphId(cp) == 0)
+                    (missing ?? (missing = new HashSet<int>())).Add(cp);
+            }
+            if (missing != null)
+                EmbedFallbackFont(pdfDoc, pdfFontName, missing, fontResolver);
+        }
+    }
+
+    /// <summary>
+    /// Embed a symbol-capable system font covering codepoints the main font
+    /// lacks, registered as "&lt;fontName&gt;-FB" for mid-run font switching.
+    /// </summary>
+    private static void EmbedFallbackFont(PdfDocument pdfDoc, string pdfFontName,
+        HashSet<int> missing, Text.FontResolver fontResolver)
+    {
+        string[] symbolFonts =
+        {
+            "Segoe UI Symbol", "seguisym", "Apple Symbols", "DejaVuSans",
+            "NotoSansSymbols2", "NotoSansSymbols", "Segoe UI Emoji", "seguiemj"
+        };
+
+        foreach (var candidate in symbolFonts)
+        {
+            var fb = fontResolver.Resolve(candidate);
+            if (fb == null || fb.RawData == null || fb.RawData.Length == 0) continue;
+
+            bool covers = false;
+            foreach (var cp in missing)
+            {
+                if (fb.GetGlyphId(cp) > 0) { covers = true; break; }
+            }
+            if (!covers) continue;
+
+            var fbSubset = Text.TrueType.TtfSubsetter.Subset(fb, missing);
+            if (fbSubset == null || fbSubset.FontData.Length == 0) continue;
+
+            pdfDoc.AddEmbeddedFont(
+                pdfFontName + "-FB",
+                fbSubset.FontData,
+                fbSubset.CodepointToNewGlyphId,
+                fbSubset.AdvanceWidths,
+                fb.UnitsPerEm,
+                fb.Ascent,
+                fb.Descent);
+            return;
         }
     }
 

--- a/src/EggPdf/HtmlToPdf.cs
+++ b/src/EggPdf/HtmlToPdf.cs
@@ -233,13 +233,22 @@ public static class HtmlToPdf
         sheet.ImportRules.Clear();
     }
 
-    /// <summary>Load CSS text from a URL (data: URI or file path).</summary>
+    /// <summary>Load CSS text from a URL (data: URI, http(s) URL, or file path).</summary>
     internal static string? LoadCssText(string url, string? basePath)
     {
         // Data URI: data:text/css;base64,...  or  data:text/css,...
         if (url.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
         {
             return DecodeDataUri(url);
+        }
+
+        // Remote stylesheet (e.g. Google Fonts <link>): fetch over HTTP(S) so
+        // @font-face webfont declarations are available for embedding.
+        if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            var bytes = Text.FontUrlFetcher.Fetch(url);
+            return bytes != null && bytes.Length > 0 ? Encoding.UTF8.GetString(bytes) : null;
         }
 
         // Resolve relative path against basePath
@@ -444,20 +453,24 @@ public static class HtmlToPdf
     }
 
     /// <summary>
-    /// Walk the layout tree, find text using TrueType system fonts, subset them,
+    /// Walk the layout tree, find text needing a real font program, subset it,
     /// and register as CIDFont Type 2 in the PDF document.
+    /// A font is embedded when the text's font-family list references a declared
+    /// @font-face (webfont), or when its codepoints exceed WinAnsiEncoding
+    /// (e.g. Vietnamese) so the non-embedded Type1 built-ins cannot encode them.
     /// </summary>
     private static void SubsetAndEmbedFonts(LayoutBox root, PdfDocument pdfDoc,
         List<CssStyleSheet>? stylesheets = null)
     {
-        // Collect all (fontName, codepoints) used in the document
+        // Collect (fontName, codepoints) plus the raw font-family list per font name
         var fontCodepoints = new Dictionary<string, HashSet<int>>();
-        CollectTextCodepoints(root, fontCodepoints);
+        var fontFamilyLists = new Dictionary<string, string>();
+        CollectTextCodepoints(root, fontCodepoints, fontFamilyLists);
 
         if (fontCodepoints.Count == 0) return;
 
-        // Build lookup: normalized PDF font name -> @font-face src value
-        var fontFaceSrcs = BuildFontFaceMap(stylesheets);
+        // Build lookup: @font-face family (lowercase) -> declared face variants
+        var fontFaces = BuildFontFaceMap(stylesheets);
 
         var fontResolver = new Text.FontResolver();
 
@@ -466,44 +479,35 @@ public static class HtmlToPdf
             var pdfFontName = kv.Key;
             var codepoints = kv.Value;
 
-            // Only embed if this is NOT a standard PDF built-in font
-            if (IsStandardPdfFont(pdfFontName)) continue;
+            bool bold = pdfFontName.IndexOf("Bold", StringComparison.OrdinalIgnoreCase) >= 0;
+            bool italic = pdfFontName.IndexOf("Italic", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                          pdfFontName.IndexOf("Oblique", StringComparison.OrdinalIgnoreCase) >= 0;
+            fontFamilyLists.TryGetValue(pdfFontName, out var familyList);
 
-            // Try @font-face src first, then fall back to system font resolver
-            Text.TrueType.FontData? fontData = null;
+            // 1. Webfont: first family in the list with a declared @font-face wins,
+            //    mirroring the browser's font selection.
+            Text.TrueType.FontData? fontData =
+                TryResolveFontFace(familyList, fontFaces, bold, italic, fontResolver);
 
-            if (fontFaceSrcs.TryGetValue(pdfFontName, out var srcValue))
+            // 2. Standard built-in Type1 fonts (WinAnsiEncoding) stay non-embedded
+            //    while every codepoint is WinAnsi-encodable and no webfont applies.
+            bool isStandard = IsStandardPdfFont(pdfFontName);
+            if (fontData == null && isStandard && AllWinAnsiEncodable(codepoints))
+                continue;
+
+            // 3. System fonts: real families from the list, then metric-compatible
+            //    substitutes for the standard font class.
+            if (fontData == null)
+                fontData = TryResolveSystemFont(familyList, fontResolver, bold, italic);
+
+            if (fontData == null)
             {
-                // Parse src: may be comma-separated list of url() or local()
-                var srcParts = srcValue.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (var srcPart in srcParts)
+                foreach (var candidate in GetSystemFontCandidates(pdfFontName))
                 {
-                    var url = Text.FontUrlFetcher.ParseFontSrcUrl(srcPart.Trim());
-                    if (url == null) continue;
-
-                    if (url.StartsWith("local:", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // local("FontName") — resolve via system
-                        var localName = url.Substring(6);
-                        fontData = fontResolver.Resolve(localName);
-                    }
-                    else
-                    {
-                        var rawBytes = Text.FontUrlFetcher.Fetch(url);
-                        if (rawBytes != null && rawBytes.Length > 0)
-                        {
-                            try { fontData = Text.TrueType.TtfParser.Parse(rawBytes); }
-                            catch { fontData = null; }
-                        }
-                    }
-
+                    fontData = fontResolver.Resolve(candidate, bold, italic);
                     if (fontData != null) break;
                 }
             }
-
-            // Fall back to system font resolver
-            if (fontData == null)
-                fontData = fontResolver.Resolve(pdfFontName);
 
             if (fontData == null || fontData.RawData == null || fontData.RawData.Length == 0)
                 continue;
@@ -526,12 +530,153 @@ public static class HtmlToPdf
     }
 
     /// <summary>
-    /// Build a map from normalized PDF font name to @font-face src value.
-    /// Scans all font-face rules in all stylesheets.
+    /// Walk a CSS font-family list and load the first family that has a declared
+    /// @font-face, picking the variant closest to the requested weight/style.
     /// </summary>
-    private static Dictionary<string, string> BuildFontFaceMap(List<CssStyleSheet>? stylesheets)
+    private static Text.TrueType.FontData? TryResolveFontFace(string? familyList,
+        Dictionary<string, List<FontFaceCandidate>> fontFaces, bool bold, bool italic,
+        Text.FontResolver fontResolver)
     {
-        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(familyList) || fontFaces.Count == 0) return null;
+
+        var families = familyList!.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var rawFamily in families)
+        {
+            var family = rawFamily.Trim().Trim('"', '\'').ToLowerInvariant();
+            if (family.Length == 0) continue;
+            if (!fontFaces.TryGetValue(family, out var candidates)) continue;
+
+            var face = SelectFontFace(candidates, bold, italic);
+            if (face == null) continue;
+
+            // src may list alternatives: url(...) format(...), local(...), ...
+            var srcParts = face.Src.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var srcPart in srcParts)
+            {
+                var url = Text.FontUrlFetcher.ParseFontSrcUrl(srcPart.Trim());
+                if (url == null) continue;
+
+                Text.TrueType.FontData? fontData = null;
+                if (url.StartsWith("local:", StringComparison.OrdinalIgnoreCase))
+                {
+                    fontData = fontResolver.Resolve(url.Substring(6), bold, italic);
+                }
+                else
+                {
+                    var rawBytes = Text.FontUrlFetcher.Fetch(url);
+                    if (rawBytes != null && rawBytes.Length > 0)
+                    {
+                        try { fontData = Text.TrueType.TtfParser.Parse(rawBytes); }
+                        catch { fontData = null; }
+                    }
+                }
+
+                if (fontData != null) return fontData;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Pick the @font-face variant best matching the requested weight/style.</summary>
+    private static FontFaceCandidate? SelectFontFace(List<FontFaceCandidate> candidates, bool bold, bool italic)
+    {
+        if (candidates.Count == 0) return null;
+
+        int targetWeight = bold ? 700 : 400;
+        FontFaceCandidate? best = null;
+        int bestScore = int.MaxValue;
+
+        foreach (var c in candidates)
+        {
+            // Style mismatch is worse than any weight distance
+            int score = Math.Abs(c.Weight - targetWeight) + (c.Italic != italic ? 10000 : 0);
+            if (score < bestScore)
+            {
+                bestScore = score;
+                best = c;
+            }
+        }
+
+        return best;
+    }
+
+    /// <summary>Resolve the first family in a CSS font-family list to an installed system font.</summary>
+    private static Text.TrueType.FontData? TryResolveSystemFont(string? familyList,
+        Text.FontResolver fontResolver, bool bold, bool italic)
+    {
+        if (string.IsNullOrEmpty(familyList)) return null;
+
+        var families = familyList!.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var rawFamily in families)
+        {
+            var family = rawFamily.Trim().Trim('"', '\'');
+            if (family.Length == 0) continue;
+
+            var fontData = fontResolver.Resolve(family, bold, italic);
+            if (fontData != null) return fontData;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Metric-compatible system font candidates for a standard PDF font name,
+    /// covering Windows, macOS, and Linux (Liberation/DejaVu/Noto) installs.
+    /// </summary>
+    private static string[] GetSystemFontCandidates(string pdfFontName)
+    {
+        if (pdfFontName.StartsWith("Times", StringComparison.OrdinalIgnoreCase))
+            return new[] { "Times New Roman", "Times", "LiberationSerif", "DejaVuSerif", "NotoSerif" };
+        if (pdfFontName.StartsWith("Courier", StringComparison.OrdinalIgnoreCase))
+            return new[] { "Courier New", "Courier", "LiberationMono", "DejaVuSansMono", "NotoSansMono" };
+        if (pdfFontName.StartsWith("Symbol", StringComparison.OrdinalIgnoreCase) ||
+            pdfFontName.StartsWith("ZapfDingbats", StringComparison.OrdinalIgnoreCase))
+            return Array.Empty<string>();
+        // Helvetica / Arial / anything else sans-like
+        return new[] { "Arial", "Helvetica", "LiberationSans", "DejaVuSans", "NotoSans" };
+    }
+
+    /// <summary>True when every codepoint can be encoded in WinAnsiEncoding.</summary>
+    private static bool AllWinAnsiEncodable(HashSet<int> codepoints)
+    {
+        foreach (var cp in codepoints)
+            if (!IsWinAnsiEncodable(cp)) return false;
+        return true;
+    }
+
+    /// <summary>Mirror of PdfPage.MapToWinAnsi: codepoints representable in WinAnsiEncoding.</summary>
+    private static bool IsWinAnsiEncodable(int cp)
+    {
+        if (cp < 0x80) return true;               // ASCII
+        if (cp >= 0xA0 && cp <= 0xFF) return true; // Latin-1 Supplement
+        switch (cp)
+        {
+            case 0x2022: case 0x2013: case 0x2014: case 0x2018: case 0x2019:
+            case 0x201C: case 0x201D: case 0x2026: case 0x2020: case 0x2021:
+            case 0x2030: case 0x2039: case 0x203A: case 0x0152: case 0x0153:
+            case 0x0160: case 0x0161: case 0x0178: case 0x0192: case 0x02C6:
+            case 0x02DC: case 0x2122:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private class FontFaceCandidate
+    {
+        public int Weight;
+        public bool Italic;
+        public string Src = "";
+    }
+
+    /// <summary>
+    /// Build a map from @font-face family name (lowercase) to its declared face
+    /// variants (weight, style, src). Scans all font-face rules in all stylesheets.
+    /// </summary>
+    private static Dictionary<string, List<FontFaceCandidate>> BuildFontFaceMap(List<CssStyleSheet>? stylesheets)
+    {
+        var result = new Dictionary<string, List<FontFaceCandidate>>(StringComparer.Ordinal);
         if (stylesheets == null) return result;
 
         foreach (var sheet in stylesheets)
@@ -552,17 +697,46 @@ public static class HtmlToPdf
 
                 if (string.IsNullOrEmpty(family) || string.IsNullOrEmpty(src)) continue;
 
-                // Map to the same PDF font name the renderer will use
-                var pdfName = Layout.StandardFontMetrics.ResolvePdfFontName(family, weight, fontStyle);
-                if (!result.ContainsKey(pdfName))
-                    result[pdfName] = src;
+                var key = family!.ToLowerInvariant();
+                if (!result.TryGetValue(key, out var list))
+                {
+                    list = new List<FontFaceCandidate>();
+                    result[key] = list;
+                }
+
+                list.Add(new FontFaceCandidate
+                {
+                    Weight = ParseFontWeight(weight),
+                    Italic = fontStyle != null &&
+                             (fontStyle.IndexOf("italic", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                              fontStyle.IndexOf("oblique", StringComparison.OrdinalIgnoreCase) >= 0),
+                    Src = src!
+                });
             }
         }
 
         return result;
     }
 
-    private static void CollectTextCodepoints(LayoutBox box, Dictionary<string, HashSet<int>> fontCodepoints)
+    /// <summary>Parse a font-weight declaration ("400", "bold", "300 700") to a numeric weight.</summary>
+    private static int ParseFontWeight(string? weight)
+    {
+        if (string.IsNullOrEmpty(weight)) return 400;
+        var w = weight!.Trim();
+
+        if (w.Equals("bold", StringComparison.OrdinalIgnoreCase)) return 700;
+        if (w.Equals("normal", StringComparison.OrdinalIgnoreCase)) return 400;
+
+        // Range like "300 700" — use the first bound
+        int space = w.IndexOf(' ');
+        if (space > 0) w = w.Substring(0, space);
+
+        return int.TryParse(w, System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture, out int value) ? value : 400;
+    }
+
+    private static void CollectTextCodepoints(LayoutBox box, Dictionary<string, HashSet<int>> fontCodepoints,
+        Dictionary<string, string> fontFamilyLists)
     {
         if (!string.IsNullOrEmpty(box.Text))
         {
@@ -575,23 +749,51 @@ public static class HtmlToPdf
                 fontCodepoints[fontName] = codepoints;
             }
 
-            for (int i = 0; i < box.Text.Length; i++)
+            // Remember the raw font-family list so embedding can honor @font-face
+            // webfonts and real system families, not just the standard mapping.
+            var familyList = box.Style?.FontFamily;
+            if (!string.IsNullOrEmpty(familyList) && !fontFamilyLists.ContainsKey(fontName))
+                fontFamilyLists[fontName] = familyList!;
+
+            AddCodepoints(codepoints, box.Text!);
+
+            // The renderer applies text-transform / small-caps at paint time, so the
+            // subset must also cover the transformed characters.
+            var textTransform = box.Style?.Get("text-transform");
+            var fontVariant = box.Style?.Get("font-variant");
+            bool transforms = (!string.IsNullOrEmpty(textTransform) && textTransform != "none") ||
+                              (fontVariant != null && fontVariant.IndexOf("small-caps", StringComparison.OrdinalIgnoreCase) >= 0);
+            if (transforms)
             {
-                char c = box.Text[i];
-                if (char.IsHighSurrogate(c) && i + 1 < box.Text.Length && char.IsLowSurrogate(box.Text[i + 1]))
-                {
-                    codepoints.Add(char.ConvertToUtf32(c, box.Text[i + 1]));
-                    i++;
-                }
-                else
-                {
-                    codepoints.Add(c);
-                }
+                AddCodepoints(codepoints, box.Text!.ToUpperInvariant());
+                AddCodepoints(codepoints, box.Text!.ToLowerInvariant());
             }
+
+            // text-overflow: ellipsis may append "..." at paint time
+            if (box.Style?.Get("text-overflow") == "ellipsis")
+                codepoints.Add('.');
         }
 
         foreach (var child in box.Children)
-            CollectTextCodepoints(child, fontCodepoints);
+            CollectTextCodepoints(child, fontCodepoints, fontFamilyLists);
+    }
+
+    /// <summary>Add every codepoint of a string (surrogate-pair aware) to the set.</summary>
+    private static void AddCodepoints(HashSet<int> codepoints, string text)
+    {
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (char.IsHighSurrogate(c) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
+            {
+                codepoints.Add(char.ConvertToUtf32(c, text[i + 1]));
+                i++;
+            }
+            else
+            {
+                codepoints.Add(c);
+            }
+        }
     }
 
     private static bool IsStandardPdfFont(string fontName)

--- a/src/EggPdf/HtmlToPdf.cs
+++ b/src/EggPdf/HtmlToPdf.cs
@@ -82,26 +82,53 @@ public static class HtmlToPdf
         // 4. Create CascadeResolver with parsed stylesheets (replaces BasicStyleResolver)
         var cascadeResolver = new CascadeResolver(stylesheets, mediaType: "print", pageWidth: pageWidthPx);
 
-        // 5. Layout (uses cascade resolver for full CSS support)
-        // Layout uses content area (page minus margins) for body width
-        var layoutRoot = BlockLayout.LayoutDocument(document, contentWidthPx, contentHeightPx, cascadeResolver);
+        // 4b. When @font-face webfonts are declared, measure text with the real
+        // font metrics so layout matches the glyphs the PDF paints.
+        var fontFaces = BuildFontFaceMap(stylesheets);
+        if (fontFaces.Count > 0)
+        {
+            var measureResolver = new Text.FontResolver();
+            var measureCache = new Dictionary<string, Text.TrueType.FontData?>(StringComparer.Ordinal);
+            TextMeasurer.FontDataProvider = (family, weight, fontStyle) =>
+            {
+                if (string.IsNullOrEmpty(family)) return null;
+                var key = family + "|" + weight + "|" + fontStyle;
+                if (measureCache.TryGetValue(key, out var cached)) return cached;
 
-        // 6. Resolve images (load data from src attributes)
-        var pdfDoc = new PdfDocument();
-        ResolveImages(layoutRoot, pdfDoc);
+                bool bold = weight == "bold" || weight == "700" || weight == "800" || weight == "900";
+                bool italic = fontStyle == "italic" || fontStyle == "oblique";
+                var data = TryResolveFontFace(family, fontFaces, bold, italic, measureResolver);
+                measureCache[key] = data;
+                return data;
+            };
+        }
 
-        // 6b. Subset and embed TrueType fonts for non-standard fonts
-        // Pass stylesheets so @font-face src URLs are tried before system font lookup.
-        SubsetAndEmbedFonts(layoutRoot, pdfDoc, stylesheets);
+        try
+        {
+            // 5. Layout (uses cascade resolver for full CSS support)
+            // Layout uses content area (page minus margins) for body width
+            var layoutRoot = BlockLayout.LayoutDocument(document, contentWidthPx, contentHeightPx, cascadeResolver);
 
-        // 7. Render to PDF
-        float pageWidthPt = pageWidthPx * PdfCoordinates.PxToPt;
-        float pageHeightPt = pageHeightPx * PdfCoordinates.PxToPt;
+            // 6. Resolve images (load data from src attributes)
+            var pdfDoc = new PdfDocument();
+            ResolveImages(layoutRoot, pdfDoc);
 
-        PdfRenderer.Render(layoutRoot, pdfDoc, pageWidthPt, pageHeightPt, pageHeightPx,
-            pageSettings.MarginLeft, pageSettings.MarginTop);
+            // 6b. Subset and embed TrueType fonts for non-standard fonts
+            SubsetAndEmbedFonts(layoutRoot, pdfDoc, fontFaces);
 
-        return pdfDoc.ToByteArray();
+            // 7. Render to PDF
+            float pageWidthPt = pageWidthPx * PdfCoordinates.PxToPt;
+            float pageHeightPt = pageHeightPx * PdfCoordinates.PxToPt;
+
+            PdfRenderer.Render(layoutRoot, pdfDoc, pageWidthPt, pageHeightPt, pageHeightPx,
+                pageSettings.MarginLeft, pageSettings.MarginTop);
+
+            return pdfDoc.ToByteArray();
+        }
+        finally
+        {
+            TextMeasurer.FontDataProvider = null;
+        }
     }
 
     /// <summary>
@@ -460,7 +487,7 @@ public static class HtmlToPdf
     /// (e.g. Vietnamese) so the non-embedded Type1 built-ins cannot encode them.
     /// </summary>
     private static void SubsetAndEmbedFonts(LayoutBox root, PdfDocument pdfDoc,
-        List<CssStyleSheet>? stylesheets = null)
+        Dictionary<string, List<FontFaceCandidate>> fontFaces)
     {
         // Collect (fontName, codepoints) plus the raw font-family list per font name
         var fontCodepoints = new Dictionary<string, HashSet<int>>();
@@ -468,9 +495,6 @@ public static class HtmlToPdf
         CollectTextCodepoints(root, fontCodepoints, fontFamilyLists);
 
         if (fontCodepoints.Count == 0) return;
-
-        // Build lookup: @font-face family (lowercase) -> declared face variants
-        var fontFaces = BuildFontFaceMap(stylesheets);
 
         var fontResolver = new Text.FontResolver();
 

--- a/src/EggPdf/HtmlToPdf.cs
+++ b/src/EggPdf/HtmlToPdf.cs
@@ -100,9 +100,8 @@ public static class HtmlToPdf
                 var key = family + "|" + weight + "|" + fontStyle;
                 if (measureCache.TryGetValue(key, out var cached)) return cached;
 
-                bool bold = weight == "bold" || weight == "700" || weight == "800" || weight == "900";
                 bool italic = fontStyle == "italic" || fontStyle == "oblique";
-                var data = TryResolveFontFace(family, fontFaces, bold, italic, measureResolver);
+                var data = TryResolveFontFace(family, fontFaces, ParseFontWeight(weight), italic, measureResolver);
                 measureCache[key] = data;
                 return data;
             };
@@ -554,12 +553,14 @@ public static class HtmlToPdf
             bool bold = pdfFontName.IndexOf("Bold", StringComparison.OrdinalIgnoreCase) >= 0;
             bool italic = pdfFontName.IndexOf("Italic", StringComparison.OrdinalIgnoreCase) >= 0 ||
                           pdfFontName.IndexOf("Oblique", StringComparison.OrdinalIgnoreCase) >= 0;
+            int targetWeight = ParseWeightSuffix(pdfFontName) ?? (bold ? 700 : 400);
+            if (targetWeight >= 600) bold = true;
             fontFamilyLists.TryGetValue(pdfFontName, out var familyList);
 
             // 1. Webfont: first family in the list with a declared @font-face wins,
             //    mirroring the browser's font selection.
             Text.TrueType.FontData? fontData =
-                TryResolveFontFace(familyList, fontFaces, bold, italic, fontResolver);
+                TryResolveFontFace(familyList, fontFaces, targetWeight, italic, fontResolver);
 
             // 2. Standard built-in Type1 fonts (WinAnsiEncoding) stay non-embedded
             //    while every codepoint is WinAnsi-encodable and no webfont applies.
@@ -657,7 +658,7 @@ public static class HtmlToPdf
     /// @font-face, picking the variant closest to the requested weight/style.
     /// </summary>
     private static Text.TrueType.FontData? TryResolveFontFace(string? familyList,
-        Dictionary<string, List<FontFaceCandidate>> fontFaces, bool bold, bool italic,
+        Dictionary<string, List<FontFaceCandidate>> fontFaces, int targetWeight, bool italic,
         Text.FontResolver fontResolver)
     {
         if (string.IsNullOrEmpty(familyList) || fontFaces.Count == 0) return null;
@@ -669,7 +670,7 @@ public static class HtmlToPdf
             if (family.Length == 0) continue;
             if (!fontFaces.TryGetValue(family, out var candidates)) continue;
 
-            var face = SelectFontFace(candidates, bold, italic);
+            var face = SelectFontFace(candidates, targetWeight, italic);
             if (face == null) continue;
 
             // src may list alternatives: url(...) format(...), local(...), ...
@@ -682,7 +683,7 @@ public static class HtmlToPdf
                 Text.TrueType.FontData? fontData = null;
                 if (url.StartsWith("local:", StringComparison.OrdinalIgnoreCase))
                 {
-                    fontData = fontResolver.Resolve(url.Substring(6), bold, italic);
+                    fontData = fontResolver.Resolve(url.Substring(6), targetWeight >= 600, italic);
                 }
                 else
                 {
@@ -702,11 +703,10 @@ public static class HtmlToPdf
     }
 
     /// <summary>Pick the @font-face variant best matching the requested weight/style.</summary>
-    private static FontFaceCandidate? SelectFontFace(List<FontFaceCandidate> candidates, bool bold, bool italic)
+    private static FontFaceCandidate? SelectFontFace(List<FontFaceCandidate> candidates, int targetWeight, bool italic)
     {
         if (candidates.Count == 0) return null;
 
-        int targetWeight = bold ? 700 : 400;
         FontFaceCandidate? best = null;
         int bestScore = int.MaxValue;
 
@@ -839,6 +839,17 @@ public static class HtmlToPdf
         }
 
         return result;
+    }
+
+    /// <summary>Extract the numeric weight from a "-W###" PDF font name suffix, if present.</summary>
+    private static int? ParseWeightSuffix(string pdfFontName)
+    {
+        int idx = pdfFontName.LastIndexOf("-W", StringComparison.Ordinal);
+        if (idx <= 0 || idx + 2 >= pdfFontName.Length) return null;
+        for (int i = idx + 2; i < pdfFontName.Length; i++)
+            if (!char.IsDigit(pdfFontName[i])) return null;
+        return int.Parse(pdfFontName.Substring(idx + 2),
+            System.Globalization.CultureInfo.InvariantCulture);
     }
 
     /// <summary>Parse a font-weight declaration ("400", "bold", "300 700") to a numeric weight.</summary>

--- a/src/EggPdf/PdfRenderer.cs
+++ b/src/EggPdf/PdfRenderer.cs
@@ -927,9 +927,26 @@ internal static class PdfRenderer
                 var glyphIds = _currentPdfDoc.GetGlyphIds(fontName, paintText);
                 if (glyphIds != null && glyphIds.Length > 0)
                 {
-                    page.AddTextCID(glyphIds, pdfX, pdfY, fontName, pdfFontSize,
-                        color?.R / 255f ?? 0, color?.G / 255f ?? 0, color?.B / 255f ?? 0,
-                        letterSpacing, wordSpacing);
+                    // Glyphs missing from the main font route to the embedded
+                    // "-FB" fallback font mid-run instead of painting .notdef.
+                    string fallbackName = fontName + "-FB";
+                    bool hasNotdef = false;
+                    for (int gi = 0; gi < glyphIds.Length; gi++)
+                        if (glyphIds[gi] == 0) { hasNotdef = true; break; }
+
+                    if (hasNotdef && _currentPdfDoc.IsEmbeddedFont(fallbackName))
+                    {
+                        var runs = BuildFontFallbackRuns(paintText, fontName, fallbackName);
+                        page.AddTextRunsCID(runs, pdfX, pdfY, pdfFontSize,
+                            color?.R / 255f ?? 0, color?.G / 255f ?? 0, color?.B / 255f ?? 0,
+                            letterSpacing, wordSpacing);
+                    }
+                    else
+                    {
+                        page.AddTextCID(glyphIds, pdfX, pdfY, fontName, pdfFontSize,
+                            color?.R / 255f ?? 0, color?.G / 255f ?? 0, color?.B / 255f ?? 0,
+                            letterSpacing, wordSpacing);
+                    }
                 }
                 else
                 {
@@ -1118,6 +1135,56 @@ internal static class PdfRenderer
         // Restore transform state
         if (hasTransform)
             page.RestoreState();
+    }
+
+    /// <summary>
+    /// Split text into consecutive runs of (fontName, glyphIds): codepoints the
+    /// main font covers stay in it; missing ones use the fallback font (or stay
+    /// as .notdef in the main font when the fallback lacks them too).
+    /// </summary>
+    private static List<(string fontName, ushort[] glyphIds)> BuildFontFallbackRuns(
+        string text, string mainFont, string fallbackFont)
+    {
+        var runs = new List<(string fontName, ushort[] glyphIds)>();
+        var current = new List<ushort>();
+        string currentFont = mainFont;
+
+        for (int i = 0; i < text.Length; i++)
+        {
+            int cp = text[i];
+            if (char.IsHighSurrogate(text[i]) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
+            {
+                cp = char.ConvertToUtf32(text[i], text[i + 1]);
+                i++;
+            }
+
+            string font = mainFont;
+            if (!_currentPdfDoc!.TryGetGlyphId(mainFont, cp, out var gid) || gid == 0)
+            {
+                if (_currentPdfDoc.TryGetGlyphId(fallbackFont, cp, out var fbGid) && fbGid > 0)
+                {
+                    font = fallbackFont;
+                    gid = fbGid;
+                }
+                else
+                {
+                    gid = 0; // .notdef in the main font
+                }
+            }
+
+            if (font != currentFont && current.Count > 0)
+            {
+                runs.Add((currentFont, current.ToArray()));
+                current.Clear();
+            }
+            currentFont = font;
+            current.Add(gid);
+        }
+
+        if (current.Count > 0)
+            runs.Add((currentFont, current.ToArray()));
+
+        return runs;
     }
 
     private static string CapitalizeText(string text)

--- a/src/EggPdf/PdfRenderer.cs
+++ b/src/EggPdf/PdfRenderer.cs
@@ -950,14 +950,16 @@ internal static class PdfRenderer
                 }
                 else
                 {
-                    page.AddText(paintText, pdfX, pdfY, fontName, pdfFontSize,
+                    page.AddText(paintText, pdfX, pdfY, StripWeightSuffix(fontName), pdfFontSize,
                         color?.R / 255f ?? 0, color?.G / 255f ?? 0, color?.B / 255f ?? 0,
                         letterSpacing, wordSpacing);
                 }
             }
             else
             {
-                page.AddText(paintText, pdfX, pdfY, fontName, pdfFontSize,
+                // Non-embedded fallback: weight-suffixed names ("Arial-W600") are
+                // not valid built-in fonts — degrade to the bucketed name.
+                page.AddText(paintText, pdfX, pdfY, StripWeightSuffix(fontName), pdfFontSize,
                     color?.R / 255f ?? 0, color?.G / 255f ?? 0, color?.B / 255f ?? 0,
                     letterSpacing, wordSpacing);
             }
@@ -1135,6 +1137,16 @@ internal static class PdfRenderer
         // Restore transform state
         if (hasTransform)
             page.RestoreState();
+    }
+
+    /// <summary>Strip a "-W###" weight suffix so built-in font fallbacks stay valid.</summary>
+    private static string StripWeightSuffix(string fontName)
+    {
+        int idx = fontName.LastIndexOf("-W", StringComparison.Ordinal);
+        if (idx <= 0 || idx + 2 >= fontName.Length) return fontName;
+        for (int i = idx + 2; i < fontName.Length; i++)
+            if (!char.IsDigit(fontName[i])) return fontName;
+        return fontName.Substring(0, idx);
     }
 
     /// <summary>

--- a/src/EggPdf/PdfRenderer.cs
+++ b/src/EggPdf/PdfRenderer.cs
@@ -843,7 +843,16 @@ internal static class PdfRenderer
             }
 
             float pdfX = textX * PdfCoordinates.PxToPt;
-            float pdfY = (pageHeightPx - adjustedY - box.PaddingTop - fontSize) * PdfCoordinates.PxToPt;
+
+            // Baseline placement like browsers: half-leading above the ascent
+            // (≈0.86em) instead of a full em below the line top — otherwise large
+            // fonts with tight line-height overlap the following line with their
+            // descenders.
+            float lineBoxHeight = box.Height > 0 ? box.Height : fontSize * 1.2f;
+            float halfLeading = (lineBoxHeight - fontSize) / 2f;
+            if (halfLeading < 0) halfLeading = 0;
+            float baselineOffset = halfLeading + fontSize * 0.86f;
+            float pdfY = (pageHeightPx - adjustedY - box.PaddingTop - baselineOffset) * PdfCoordinates.PxToPt;
 
             // Vertical-align baseline shift (sup/sub/super/sub)
             var verticalAlign = box.Style.Get("vertical-align");

--- a/src/EggPdf/PdfRenderer.cs
+++ b/src/EggPdf/PdfRenderer.cs
@@ -630,6 +630,10 @@ internal static class PdfRenderer
                             tlrPt, trrPt, brrPt, blrPt);
                     else
                         page.AddRectangle(pdfX, pdfY, pdfW, pdfH, bgR, bgG, bgB);
+
+                    // Reset opacity so it does not leak into subsequent content
+                    if (bgAlpha < 1f)
+                        page.SetOpacity(1f);
                 }
             }
 
@@ -912,6 +916,11 @@ internal static class PdfRenderer
                 }
             }
 
+            // Text alpha: rgba() color alpha combined with the element's css opacity
+            float textAlpha = (color?.A / 255f ?? 1f) * cssOpacity;
+            if (textAlpha < 1f)
+                page.SetOpacity(textAlpha);
+
             // Use CIDFont glyph IDs for embedded fonts, or WinAnsi for built-in fonts
             if (_currentPdfDoc != null && _currentPdfDoc.IsEmbeddedFont(fontName))
             {
@@ -935,6 +944,9 @@ internal static class PdfRenderer
                     color?.R / 255f ?? 0, color?.G / 255f ?? 0, color?.B / 255f ?? 0,
                     letterSpacing, wordSpacing);
             }
+
+            if (textAlpha < 1f)
+                page.SetOpacity(1f);
 
             // Text decoration (underline, line-through, overline)
             // Honour text-decoration-line, text-decoration-color, text-decoration-thickness longhands.

--- a/src/EggPdf/PdfRenderer.cs
+++ b/src/EggPdf/PdfRenderer.cs
@@ -845,13 +845,12 @@ internal static class PdfRenderer
             float pdfX = textX * PdfCoordinates.PxToPt;
 
             // Baseline placement like browsers: half-leading above the ascent
-            // (≈0.86em) instead of a full em below the line top — otherwise large
-            // fonts with tight line-height overlap the following line with their
-            // descenders.
+            // (real font metrics when available) instead of a full em below the
+            // line top — otherwise large fonts with tight line-height overlap the
+            // following line with their descenders.
             float lineBoxHeight = box.Height > 0 ? box.Height : fontSize * 1.2f;
-            float halfLeading = (lineBoxHeight - fontSize) / 2f;
-            if (halfLeading < 0) halfLeading = 0;
-            float baselineOffset = halfLeading + fontSize * 0.86f;
+            float baselineOffset = TextMeasurer.GetBaselineOffset(fontSize, lineBoxHeight,
+                box.Style.FontFamily, box.Style.FontWeight, box.Style.Get("font-style"));
             float pdfY = (pageHeightPx - adjustedY - box.PaddingTop - baselineOffset) * PdfCoordinates.PxToPt;
 
             // Vertical-align baseline shift (sup/sub/super/sub)

--- a/tests/EggPdf.Tests.Unit/EggPdf.Tests.Unit.csproj
+++ b/tests/EggPdf.Tests.Unit/EggPdf.Tests.Unit.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
     <PackageReference Include="FluentAssertions" Version="7.*" />
+    <!-- Test-only: validates the zero-dependency CMS builder against the reference implementation -->
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EggPdf.Tests.Unit/EndToEnd/BaselineAlignmentTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/BaselineAlignmentTests.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// Mixed-size inline text shares one baseline (CSS default vertical-align:
+/// baseline). Small subtitles must not float at the line top, and flex
+/// align-items:baseline must align item baselines, not item tops.
+/// </summary>
+public class BaselineAlignmentTests
+{
+    private static (float x, float y) FindTextPos(byte[] pdf, string text)
+    {
+        var content = Encoding.ASCII.GetString(pdf);
+        var m = Regex.Match(content, @"(-?\d+\.\d+) (-?\d+\.\d+) Td \(" + Regex.Escape(text) + @"\) Tj");
+        m.Success.Should().BeTrue($"'{text}' should be in the content stream");
+        return (float.Parse(m.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture),
+                float.Parse(m.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task SmallerInlineSpan_SitsOnParentBaseline()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"font-size:20px\">BIGTEXT <span style=\"font-size:10px\">SMALLTEXT</span></div></body></html>");
+
+        var big = FindTextPos(pdf, "BIGTEXT");
+        var small = FindTextPos(pdf, " SMALLTEXT");
+
+        // Baselines aligned: pdfY(big) = top+20, pdfY(small) ≈ top+shift+10 where
+        // shift ≈ (20-10)*0.8 = 8px → Td y difference ≈ 2px = 1.5pt (was 7.5pt top-aligned)
+        (small.y - big.y).Should().BeLessThan(4f,
+            "the small span must sit near the big text's baseline, not the line top");
+    }
+
+    [Fact]
+    public async Task FlexBaseline_SmallItemAlignsToBigItemBaseline()
+    {
+        string html(string align) =>
+            "<html><body><div style=\"display:flex;align-items:" + align + "\">" +
+            "<div style=\"font-size:24px\">NUM</div>" +
+            "<div style=\"font-size:12px\">TITLE</div></div></body></html>";
+
+        var baseline = await HtmlToPdf.RenderAsync(html("baseline"));
+        var flexStart = await HtmlToPdf.RenderAsync(html("flex-start"));
+
+        float titleBaselineY = FindTextPos(baseline, "TITLE").y;
+        float titleFlexStartY = FindTextPos(flexStart, "TITLE").y;
+
+        // With baseline alignment the smaller item shifts DOWN (smaller PDF y)
+        titleBaselineY.Should().BeLessThan(titleFlexStartY - 3f,
+            "align-items:baseline must move the smaller item down to the shared baseline");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/CloudflareEmailTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/CloudflareEmailTests.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// Cloudflare email obfuscation (data-cfemail) is normally decoded by a
+/// browser-side script. A PDF engine runs no JavaScript, so the DOM pass must
+/// decode it directly — otherwise "[email protected]" ends up in the PDF.
+/// </summary>
+public class CloudflareEmailTests
+{
+    [Fact]
+    public async Task DataCfEmail_IsDecodedToRealAddress()
+    {
+        // XOR key 0xAF -> "contact@vcrrm.org"
+        var html = "<html><body><p>Email: " +
+            "<a href=\"/cdn-cgi/l/email-protection\" class=\"__cf_email__\" " +
+            "data-cfemail=\"afccc0c1dbceccdbefd9ccddddc281c0ddc8\">[email&#160;protected]</a>" +
+            "</p></body></html>";
+
+        var pdf = await HtmlToPdf.RenderAsync(html);
+        var text = Encoding.GetEncoding("ISO-8859-1").GetString(pdf);
+
+        text.Should().Contain("contact@vcrrm.org");
+        text.Should().NotContain("email protected");
+    }
+
+    [Fact]
+    public async Task InvalidCfEmail_DoesNotCrash()
+    {
+        var html = "<html><body><a data-cfemail=\"zz\">[email protected]</a>" +
+                   "<a data-cfemail=\"af\">x</a></body></html>";
+
+        var act = async () => await HtmlToPdf.RenderAsync(html);
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/FlexAbsolutePositionTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/FlexAbsolutePositionTests.cs
@@ -1,0 +1,72 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// Regression tests: absolutely positioned children of a flex container are
+/// out-of-flow — they must not consume flex space, and their top/right/bottom/left
+/// offsets must be honored relative to the positioned container.
+/// </summary>
+public class FlexAbsolutePositionTests
+{
+    private static (float x, float y) FindTextPosition(byte[] pdf, string text)
+    {
+        var content = Encoding.ASCII.GetString(pdf);
+        var match = Regex.Match(content,
+            @"(-?\d+\.\d+) (-?\d+\.\d+) Td \(" + Regex.Escape(text) + @"\) Tj");
+        match.Success.Should().BeTrue($"text '{text}' should appear in the content stream");
+        return (float.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture),
+                float.Parse(match.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task FlexColumn_AbsoluteChild_DoesNotConsumeFlexSpace()
+    {
+        const string flexOpen =
+            "<div style=\"display:flex;flex-direction:column;position:relative;width:300px;height:300px\">";
+        const string absChild =
+            "<div style=\"position:absolute;top:10px;right:10px;width:50px;height:50px;background:red\"></div>";
+
+        var withAbs = await HtmlToPdf.RenderAsync(
+            $"<html><body>{flexOpen}{absChild}<p>FIRSTITEM</p></div></body></html>");
+        var withoutAbs = await HtmlToPdf.RenderAsync(
+            $"<html><body>{flexOpen}<p>FIRSTITEM</p></div></body></html>");
+
+        var posWith = FindTextPosition(withAbs, "FIRSTITEM");
+        var posWithout = FindTextPosition(withoutAbs, "FIRSTITEM");
+
+        posWith.y.Should().BeApproximately(posWithout.y, 2f,
+            "an absolutely positioned sibling must not push flex content down");
+        posWith.x.Should().BeApproximately(posWithout.x, 2f);
+    }
+
+    [Fact]
+    public async Task FlexContainer_AbsoluteChild_HonorsTopRightOffsets()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"display:flex;position:relative;width:300px;height:300px\">" +
+            "<div style=\"position:absolute;top:10px;right:10px;width:50px;height:50px;background:red\"></div>" +
+            "</div></body></html>");
+
+        var content = Encoding.ASCII.GetString(pdf);
+
+        // Red fill rect: "1.00 0.00 0.00 rg" then "x y w h re f"
+        var match = Regex.Match(content,
+            @"1\.00 0\.00 0\.00 rg\s+(-?\d+\.\d+) (-?\d+\.\d+) (-?\d+\.\d+) (-?\d+\.\d+) re f");
+        match.Success.Should().BeTrue("the absolute child's red background must be painted");
+
+        float x = float.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+        float w = float.Parse(match.Groups[3].Value, System.Globalization.CultureInfo.InvariantCulture);
+
+        // Container content starts at body offset (~6pt); container is 300px = 225pt wide.
+        // right:10px => box right edge at containerX + 225 - 7.5, box left = right - 37.5.
+        // With container at x≈6: expected x ≈ 6 + 225 - 7.5 - 37.5 = 186.
+        w.Should().BeApproximately(37.5f, 1f, "50px = 37.5pt");
+        x.Should().BeGreaterThan(150f,
+            "right:10px must place the box near the container's right edge, not at its left origin");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/FlexAbsolutePositionTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/FlexAbsolutePositionTests.cs
@@ -45,6 +45,28 @@ public class FlexAbsolutePositionTests
     }
 
     [Fact]
+    public async Task AbsoluteChild_ContainingBlockIsPaddingBox_InsideBorder()
+    {
+        // CSS 2.1 §10.1: the containing block of an absolutely positioned element
+        // is the ancestor's PADDING box — offsets count from inside the border.
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body style=\"margin:0;padding:0\">" +
+            "<div style=\"position:relative;border:10px solid #000;width:100px;height:100px\">" +
+            "<div style=\"position:absolute;left:0;top:0;width:20px;height:20px;background:#ff0000\"></div>" +
+            "</div></body></html>");
+
+        var content = Encoding.ASCII.GetString(pdf);
+        var m = Regex.Match(content,
+            @"1\.00 0\.00 0\.00 rg\s+(-?\d+\.\d+) (-?\d+\.\d+) (-?\d+\.\d+) (-?\d+\.\d+) re f");
+        m.Success.Should().BeTrue("the absolute child's red background must be painted");
+
+        float x = float.Parse(m.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+        // left:0 lands at the padding edge: 10px border = 7.5pt from the box origin
+        x.Should().BeApproximately(7.5f, 1f,
+            "left:0 must offset from inside the parent's border, not its border-box edge");
+    }
+
+    [Fact]
     public async Task FlexContainer_AbsoluteChild_HonorsTopRightOffsets()
     {
         var pdf = await HtmlToPdf.RenderAsync(

--- a/tests/EggPdf.Tests.Unit/EndToEnd/FlexAutoMarginTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/FlexAutoMarginTests.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// Auto margins on flex items absorb positive free space (CSS Flexbox §8.1) —
+/// margin-top:auto pushes a footer to the bottom of a column flex container.
+/// </summary>
+public class FlexAutoMarginTests
+{
+    private static float FindTextY(byte[] pdf, string text)
+    {
+        var content = Encoding.ASCII.GetString(pdf);
+        var m = Regex.Match(content, @"(-?\d+\.\d+) (-?\d+\.\d+) Td \(" + Regex.Escape(text) + @"\) Tj");
+        m.Success.Should().BeTrue($"'{text}' should be painted");
+        return float.Parse(m.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    [Fact]
+    public async Task MarginTopAuto_PushesItemToContainerBottom()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body style=\"margin:0;padding:0\">" +
+            "<div style=\"display:flex;flex-direction:column;height:600px\">" +
+            "<div>TOPCONTENT</div>" +
+            "<div style=\"margin-top:auto\">BOTTOMFOOTER</div>" +
+            "</div></body></html>");
+
+        float topY = FindTextY(pdf, "TOPCONTENT");
+        float footerY = FindTextY(pdf, "BOTTOMFOOTER");
+
+        // 600px = 450pt container from the page top (841.89): footer should sit
+        // near y ≈ 841.89 - 450 + lineHeight ≈ 403, far below the top item.
+        (topY - footerY).Should().BeGreaterThan(380f,
+            "margin-top:auto must absorb the free space and push the footer to the bottom");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/FlexOverflowRegressionTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/FlexOverflowRegressionTests.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// Flex free-space math must account for item margins — otherwise flex:1
+/// over-grows and pushes later items (the certificate's page footer) off the
+/// bottom of a fixed-height page.
+/// </summary>
+public class FlexOverflowRegressionTests
+{
+    [Fact]
+    public async Task FixedHeightColumnFlex_WithMargins_KeepsLastItemOnPage()
+    {
+        // Mirrors the certificate's .page: full-page column flex, flex:1 body,
+        // margined footer. Every text op must stay within the page (y >= 0).
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body style=\"margin:0;padding:0\">" +
+            "<div style=\"display:flex;flex-direction:column;min-height:297mm;box-sizing:border-box;padding:16mm 14mm\">" +
+            "<header style=\"margin-bottom:14px\">HEADER</header>" +
+            "<div style=\"flex:1\">BODY</div>" +
+            "<div style=\"margin-top:20px\">SIGROW</div>" +
+            "<div style=\"margin-top:14px\">FOOTERLINE</div>" +
+            "</div></body></html>");
+
+        var text = Encoding.ASCII.GetString(pdf);
+        text.Should().Contain("(FOOTERLINE)", "the footer must be painted");
+
+        foreach (Match m in Regex.Matches(text, @"(-?\d+\.\d+) (-?\d+\.\d+) Td \((\w+)\) Tj"))
+        {
+            float y = float.Parse(m.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
+            y.Should().BeGreaterThan(0f,
+                $"'{m.Groups[3].Value}' must stay on the page — margins must be part of flex free-space");
+        }
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/FlexTextChildTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/FlexTextChildTests.cs
@@ -21,6 +21,20 @@ public class FlexTextChildTests
     }
 
     [Fact]
+    public async Task FlexContainer_Border_IsPaintedOnceNotOnTextItem()
+    {
+        // The anonymous text item must not inherit paintable box decorations —
+        // otherwise a bordered stamp circle renders a second inner circle.
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"display:flex;align-items:center;justify-content:center;" +
+            "width:80px;height:80px;border:3px solid #ff0000;border-radius:50%\">STAMP</div></body></html>");
+
+        var text = Encoding.ASCII.GetString(pdf);
+        System.Text.RegularExpressions.Regex.Matches(text, "1\\.00 0\\.00 0\\.00 RG").Count
+            .Should().Be(1, "the border must be stroked exactly once, on the container only");
+    }
+
+    [Fact]
     public async Task FlexContainer_TextWithBr_RendersAllLines()
     {
         // The certificate's stamp circle: centered multi-line text via <br>

--- a/tests/EggPdf.Tests.Unit/EndToEnd/FlexTextChildTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/FlexTextChildTests.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// Direct text children of a flex container form an anonymous flex item
+/// (CSS Flexbox §4). They must render, not vanish (the empty-stamp-circle bug).
+/// </summary>
+public class FlexTextChildTests
+{
+    [Fact]
+    public async Task FlexContainer_DirectText_IsRendered()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"display:flex;width:200px;height:100px\">STAMPTEXT</div></body></html>");
+
+        Encoding.ASCII.GetString(pdf).Should().Contain("STAMPTEXT");
+    }
+
+    [Fact]
+    public async Task FlexContainer_TextWithBr_RendersAllLines()
+    {
+        // The certificate's stamp circle: centered multi-line text via <br>
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"display:flex;align-items:center;justify-content:center;" +
+            "width:120px;height:120px;text-align:center\">LINEONE<br>LINETWO</div></body></html>");
+
+        var text = Encoding.ASCII.GetString(pdf);
+        text.Should().Contain("LINEONE");
+        text.Should().Contain("LINETWO");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/FontWeightVariantTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/FontWeightVariantTests.cs
@@ -1,0 +1,49 @@
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// When @font-face declares multiple weights, intermediate font-weight values
+/// (500, 600, 800...) must select and embed the matching face instead of
+/// bucketing everything into regular/bold — otherwise semibold labels render
+/// visibly thinner than the browser.
+/// </summary>
+public class FontWeightVariantTests
+{
+    [Fact]
+    public async Task IntermediateWeight_EmbedsDistinctFontFace()
+    {
+        // Two local() faces under one family; weight 600 must get its own
+        // embedded font (name carries the weight), separate from weight 400.
+        var html =
+            "<html><head><style>" +
+            "@font-face { font-family: T; font-weight: 400; src: local('Arial'); }" +
+            "@font-face { font-family: T; font-weight: 600; src: local('Arial Bold'); }" +
+            "p { font-family: T; }" +
+            "</style></head><body>" +
+            "<p>regular text</p>" +
+            "<p style=\"font-weight:600\">semibold text</p>" +
+            "</body></html>";
+
+        var pdf = await HtmlToPdf.RenderAsync(html);
+        var text = Encoding.GetEncoding("ISO-8859-1").GetString(pdf);
+
+        text.Should().Contain("-W600", "weight 600 must produce its own font resource");
+        text.Should().Contain("/FontFile2");
+    }
+
+    [Fact]
+    public async Task IntermediateWeight_WithoutWebfonts_KeepsStandardNames()
+    {
+        // No @font-face: weight 600 stays in the classic bold bucket with
+        // built-in fonts — no behavior change for plain documents.
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p style=\"font-weight:600\">plain semibold</p></body></html>");
+
+        var text = Encoding.GetEncoding("ISO-8859-1").GetString(pdf);
+        text.Should().NotContain("-W600");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/GlyphFallbackTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/GlyphFallbackTests.cs
@@ -1,0 +1,46 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// When the selected font lacks a glyph (e.g. ⚠ U+26A0 in most text fonts),
+/// the engine must embed a symbol-capable fallback font and switch fonts
+/// mid-run instead of painting .notdef boxes.
+/// </summary>
+public class GlyphFallbackTests
+{
+    [Fact]
+    public async Task WarningSign_InVietnameseText_DoesNotPaintNotdef()
+    {
+        // Vietnamese forces CIDFont embedding; ⚠ is absent from most text fonts
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p>Cảnh báo ⚠ nguy hiểm</p></body></html>");
+
+        var text = Encoding.GetEncoding("ISO-8859-1").GetString(pdf);
+        text.Should().Contain("/FontFile2");
+
+        // No CID hex string may contain a .notdef (0000) glyph
+        foreach (Match m in Regex.Matches(text, @"<([0-9A-Fa-f]+)>\s*Tj"))
+        {
+            var hex = m.Groups[1].Value;
+            for (int i = 0; i + 4 <= hex.Length; i += 4)
+                hex.Substring(i, 4).Should().NotBe("0000",
+                    "missing glyphs must be routed to the fallback font, not painted as .notdef");
+        }
+    }
+
+    [Fact]
+    public async Task WarningSign_FallbackFontIsEmbedded()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p>Lưu ý ⚠ quan trọng</p></body></html>");
+
+        var text = Encoding.GetEncoding("ISO-8859-1").GetString(pdf);
+        // The main text font plus (when the main font lacks U+26A0) a -FB fallback
+        Regex.Matches(text, "/FontFile2").Count.Should().BeGreaterThanOrEqualTo(1);
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/GridItemPositionTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/GridItemPositionTests.cs
@@ -1,0 +1,70 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// Regression tests for grid item positioning: every grid cell's content must
+/// paint at the cell's position, not at the grid container's origin.
+/// </summary>
+public class GridItemPositionTests
+{
+    private static (float x, float y) FindTextPosition(byte[] pdf, string text)
+    {
+        var content = Encoding.ASCII.GetString(pdf);
+        var match = Regex.Match(content,
+            @"(-?\d+\.\d+) (-?\d+\.\d+) Td \(" + Regex.Escape(text) + @"\) Tj");
+        match.Success.Should().BeTrue($"text '{text}' should appear in the content stream with coordinates");
+        return (float.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture),
+                float.Parse(match.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task Grid_TwoColumns_SecondItemOffsetHorizontally()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"display:grid;grid-template-columns:1fr 195px;gap:24px;width:600px\">" +
+            "<div>LEFTCOL</div><div>RIGHTCOL</div></div></body></html>");
+
+        var left = FindTextPosition(pdf, "LEFTCOL");
+        var right = FindTextPosition(pdf, "RIGHTCOL");
+
+        // Left column is 600-195-24 = 381px wide; right column starts at 405px ≈ 303.75pt after it
+        right.x.Should().BeGreaterThan(left.x + 250,
+            "the second grid column's content must be offset to its cell, not painted at the container origin");
+        right.y.Should().BeApproximately(left.y, 2f, "both items are on the same grid row");
+    }
+
+    [Fact]
+    public async Task Grid_ThreeFixedColumns_EachItemInItsCell()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"display:grid;grid-template-columns:100px 100px 100px\">" +
+            "<div>AAA</div><div>BBB</div><div>CCC</div></div></body></html>");
+
+        var a = FindTextPosition(pdf, "AAA");
+        var b = FindTextPosition(pdf, "BBB");
+        var c = FindTextPosition(pdf, "CCC");
+
+        // 100px = 75pt column width
+        b.x.Should().BeApproximately(a.x + 75f, 2f);
+        c.x.Should().BeApproximately(a.x + 150f, 2f);
+    }
+
+    [Fact]
+    public async Task Grid_TwoRows_SecondRowOffsetVertically()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"display:grid;grid-template-columns:1fr\">" +
+            "<div>ROWONE</div><div>ROWTWO</div></div></body></html>");
+
+        var one = FindTextPosition(pdf, "ROWONE");
+        var two = FindTextPosition(pdf, "ROWTWO");
+
+        two.y.Should().BeLessThan(one.y - 5,
+            "the second row's content must paint below the first row (PDF Y grows upward)");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/InlineBlockShrinkToFitTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/InlineBlockShrinkToFitTests.cs
@@ -1,0 +1,67 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// An auto-width inline-block shrink-wraps its content (CSS 2.1 §10.3.9) and
+/// participates in the parent's text-align — the QR frame must hug its image
+/// and sit centered in its column, not fill the full width.
+/// </summary>
+public class InlineBlockShrinkToFitTests
+{
+    // 1x1 red PNG
+    private const string Png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+    [Fact]
+    public async Task AutoWidthInlineBlock_ShrinksToContent()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"width:260px\">" +
+            "<div style=\"display:inline-block;padding:8px;background:#112233\">" +
+            $"<img src='data:image/png;base64,{Png}' style='display:block;width:100px;height:100px'>" +
+            "</div></div></body></html>");
+
+        var text = Encoding.ASCII.GetString(pdf);
+        // Frame background rect: content 100px + padding 16px = 116px = 87pt wide
+        var m = Regex.Match(text, @"(-?[\d.]+) (-?[\d.]+) ([\d.]+) ([\d.]+) re f");
+        bool found = false;
+        foreach (Match r in Regex.Matches(text, @"(-?[\d.]+) (-?[\d.]+) ([\d.]+) ([\d.]+) re f"))
+        {
+            float w = float.Parse(r.Groups[3].Value, System.Globalization.CultureInfo.InvariantCulture);
+            float h = float.Parse(r.Groups[4].Value, System.Globalization.CultureInfo.InvariantCulture);
+            if (h > 80 && h < 100 && w > 80)
+            {
+                w.Should().BeApproximately(87f, 2f, "the frame must shrink-wrap image + padding, not fill 260px");
+                found = true;
+            }
+        }
+        found.Should().BeTrue("the inline-block background rect should be painted");
+    }
+
+    [Fact]
+    public async Task InlineBlock_InCenteredParent_IsCentered()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body style=\"margin:0\"><div style=\"width:260px;text-align:center\">" +
+            "<div style=\"display:inline-block;padding:8px;background:#112233\">" +
+            $"<img src='data:image/png;base64,{Png}' style='display:block;width:100px;height:100px'>" +
+            "</div></div></body></html>");
+
+        var text = Encoding.ASCII.GetString(pdf);
+        foreach (Match r in Regex.Matches(text, @"(-?[\d.]+) (-?[\d.]+) ([\d.]+) ([\d.]+) re f"))
+        {
+            float x = float.Parse(r.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+            float w = float.Parse(r.Groups[3].Value, System.Globalization.CultureInfo.InvariantCulture);
+            float h = float.Parse(r.Groups[4].Value, System.Globalization.CultureInfo.InvariantCulture);
+            if (h > 80 && h < 100 && w > 80)
+            {
+                // container 260px = 195pt; frame 116px = 87pt → centered x = (195-87)/2 = 54pt
+                x.Should().BeApproximately(54f, 3f, "text-align:center centers the inline-block in its parent");
+            }
+        }
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/InlineBoundarySpaceTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/InlineBoundarySpaceTests.cs
@@ -25,6 +25,20 @@ public class InlineBoundarySpaceTests
     }
 
     [Fact]
+    public async Task Nbsp_BeforeInlineElement_DoesNotDoubleSpace()
+    {
+        // "Tax ID:&nbsp;<strong>value</strong>" — the NBSP is rendered content;
+        // no additional boundary space may be synthesized.
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p>Tax ID:&#160;<strong>VALUE</strong></p></body></html>");
+
+        var text = Encoding.GetEncoding("ISO-8859-1").GetString(pdf);
+        text.Should().NotContain("( VALUE)",
+            "the NBSP already provides the gap — a synthesized space would double it");
+        text.Should().Contain("(VALUE)");
+    }
+
+    [Fact]
     public async Task StrongBetweenTextRuns_MidSentence_KeepsSpaces()
     {
         var pdf = await HtmlToPdf.RenderAsync(

--- a/tests/EggPdf.Tests.Unit/EndToEnd/InlineBoundarySpaceTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/InlineBoundarySpaceTests.cs
@@ -1,0 +1,37 @@
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// Whitespace at the boundary between a text node and an inline element must
+/// collapse to a single space, not disappear ("Căn cứ&lt;strong&gt;Luật" bug).
+/// </summary>
+public class InlineBoundarySpaceTests
+{
+    [Fact]
+    public async Task TextNode_TrailingSpaceBeforeStrong_IsPreserved()
+    {
+        var pdf = await HtmlToPdf.RenderAsync("<html><body><p>foo <strong>bar</strong> baz</p></body></html>");
+        var text = Encoding.ASCII.GetString(pdf);
+
+        // The strong run must start with the boundary space: "( bar)" not "(bar)"
+        text.Should().Contain("( bar)",
+            "the space between the text node and the inline element must be preserved");
+        text.Should().Contain("( baz)",
+            "the space after the inline element must be preserved");
+    }
+
+    [Fact]
+    public async Task StrongBetweenTextRuns_MidSentence_KeepsSpaces()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div>alpha beta <strong>gamma</strong> delta</div></body></html>");
+        var text = Encoding.ASCII.GetString(pdf);
+
+        text.Should().Contain("( gamma)");
+        text.Should().Contain("( delta)");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/InlineBreakAllTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/InlineBreakAllTests.cs
@@ -1,0 +1,36 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// word-break: break-all must split an unbreakable word (URL) across lines in
+/// the inline-runs path too, not only in plain block text — the QR caption URL
+/// previously overflowed its column.
+/// </summary>
+public class InlineBreakAllTests
+{
+    [Fact]
+    public async Task LongWordInSpan_BreakAll_SplitsAcrossLines()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"width:120px;word-break:break-all\">" +
+            "intro <span>DEV.VCRRM.ORG/LICENSES/VERIFY/?C=VCRRM-2026-6QDNKQ</span></div></body></html>");
+
+        var text = Encoding.ASCII.GetString(pdf);
+
+        // The URL must be split into multiple text boxes (multiple Tj containing its fragments)
+        var pieces = Regex.Matches(text, @"\(([^)]*VCRRM[^)]*|[^)]*VERIFY[^)]*|[^)]*DEV\.[^)]*)\) Tj").Count;
+        pieces.Should().BeGreaterThan(1, "a 50-char URL cannot fit a 120px column in one piece");
+
+        // And no fragment may be wider than the container: check X positions stay in bounds
+        foreach (Match m in Regex.Matches(text, @"(-?\d+\.\d+) (-?\d+\.\d+) Td \(([^)]+)\) Tj"))
+        {
+            float x = float.Parse(m.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+            x.Should().BeLessThan(100f, "fragments start within the 120px (90pt) column");
+        }
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/LetterSpacingMeasureTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/LetterSpacingMeasureTests.cs
@@ -1,0 +1,52 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using EggPdf.Layout;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// letter-spacing is painted via the PDF Tc operator but must also be part of
+/// text MEASUREMENT, otherwise word boxes are too narrow and consecutive words
+/// overlap (the "QUÉ ĐỂXÁCTHỰC" bug in letter-spaced captions).
+/// </summary>
+public class LetterSpacingMeasureTests
+{
+    [Fact]
+    public void MeasureWidth_WithLetterSpacing_AddsPerGlyphSpacing()
+    {
+        float baseWidth = TextMeasurer.MeasureWidth("ABCD", 16, "Arial", null, null);
+        float spaced = TextMeasurer.MeasureWidth("ABCD", 16, "Arial", null, null, 2f);
+
+        // PDF Tc applies after every glyph, including the last: 4 glyphs × 2px
+        spaced.Should().BeApproximately(baseWidth + 8f, 0.01f);
+    }
+
+    private static float FindTextX(byte[] pdf, string text)
+    {
+        var content = Encoding.ASCII.GetString(pdf);
+        var m = Regex.Match(content, @"(-?\d+\.\d+) (-?\d+\.\d+) Td \(" + Regex.Escape(text) + @"\) Tj");
+        m.Success.Should().BeTrue($"'{text}' should be in the content stream");
+        return float.Parse(m.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    [Fact]
+    public async Task LetterSpacedWords_SecondWordShiftsBySpacing()
+    {
+        // The <b> sibling forces the mixed-inline path, which lays out per-word boxes
+        var plain = await HtmlToPdf.RenderAsync(
+            "<html><body><p>HELLO WORLD <b>X</b></p></body></html>");
+        var spaced = await HtmlToPdf.RenderAsync(
+            "<html><body><p style=\"letter-spacing:4px\">HELLO WORLD <b>X</b></p></body></html>");
+
+        float plainGap = FindTextX(plain, " WORLD") - FindTextX(plain, "HELLO");
+        float spacedGap = FindTextX(spaced, " WORLD") - FindTextX(spaced, "HELLO");
+
+        // "HELLO" is 5 glyphs (the boundary space belongs to the next word's box);
+        // 5 × 4px = 20px = 15pt wider gap (±2pt tolerance)
+        (spacedGap - plainGap).Should().BeApproximately(15f, 2f,
+            "the second word must start after the letter-spaced width of the first");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/OpacityLeakTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/OpacityLeakTests.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// The PDF gs operator persists until changed: after painting semi-transparent
+/// content, opacity must be explicitly reset to 1, otherwise the alpha leaks
+/// into every subsequent element (washed-out text bug).
+/// </summary>
+public class OpacityLeakTests
+{
+    [Fact]
+    public async Task SemiTransparentBackground_ResetsOpacityAfterPainting()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><div style=\"background:rgba(0,0,0,0.5);width:50px;height:20px\"></div>" +
+            "<p>after text</p></body></html>");
+
+        var text = Encoding.ASCII.GetString(pdf);
+        text.Should().Contain("/GS50 gs", "the rgba(…,0.5) background sets 50% alpha");
+        text.Should().Contain("/GS100 gs", "opacity must be reset to 1 after the transparent fill");
+
+        // The reset must come AFTER the 50% state
+        text.IndexOf("/GS100 gs").Should().BeGreaterThan(text.IndexOf("/GS50 gs"));
+    }
+
+    [Fact]
+    public async Task SemiTransparentText_ResetsOpacityAfterPainting()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p style=\"color:rgba(0,0,0,0.4)\">faded</p><p>solid</p></body></html>");
+
+        var text = Encoding.ASCII.GetString(pdf);
+        text.Should().Contain("/GS40 gs");
+        text.Should().Contain("/GS100 gs", "text alpha must not leak into the next paragraph");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/EndToEnd/PngImageE2ETests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/PngImageE2ETests.cs
@@ -79,6 +79,35 @@ public class PngImageE2ETests
     }
 
     [Fact]
+    public async Task PngImage_OneBitGrayscale_RendersInPdf()
+    {
+        // QR code generators commonly emit 1-bit grayscale PNGs (color type 0, bit depth 1)
+        var html = $"<img src='data:image/png;base64,{CreateOneBitGrayscalePngBase64()}' width='100' height='100'>";
+
+        byte[] pdf = await HtmlToPdf.RenderAsync(html);
+        var text = Encoding.ASCII.GetString(pdf);
+
+        text.Should().StartWith("%PDF");
+        text.Should().Contain("/XObject"); // image XObject present
+        text.Should().Contain("Do");       // image draw operator
+    }
+
+    [Fact]
+    public async Task PngImage_DisplayBlock_RendersInPdf()
+    {
+        // display:block on an <img> (common in CSS resets and QR frames) must not
+        // route it into the generic block path where ImageSource is lost.
+        var html = "<style>.fr { display:inline-block; padding:8px; } .fr img { display:block; width:100px; height:100px; }</style>" +
+                   $"<div class='fr'><img src='data:image/png;base64,{RedPngBase64}' alt='qr'></div>";
+
+        byte[] pdf = await HtmlToPdf.RenderAsync(html);
+        var text = Encoding.ASCII.GetString(pdf);
+
+        text.Should().Contain("/XObject");
+        text.Should().Contain("Do");
+    }
+
+    [Fact]
     public async Task PngImage_InvalidBase64_DoesNotCrash()
     {
         var html = "<img src='data:image/png;base64,NOT_VALID_PNG_DATA' width='50' height='50'>";
@@ -157,6 +186,53 @@ public class PngImageE2ETests
         WriteChunk(bw, "IDAT", compressed);
 
         // IEND chunk
+        WriteChunk(bw, "IEND", Array.Empty<byte>());
+
+        return Convert.ToBase64String(ms.ToArray());
+    }
+
+    /// <summary>Create an 8x8 checkerboard 1-bit grayscale PNG (color type 0, bit depth 1) as base64.</summary>
+    private static string CreateOneBitGrayscalePngBase64()
+    {
+        using var ms = new MemoryStream();
+        var bw = new BinaryWriter(ms);
+
+        bw.Write(new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
+
+        // IHDR: 8x8, 1-bit, grayscale (color type 0)
+        WriteChunk(bw, "IHDR", new byte[] {
+            0, 0, 0, 8,  // width
+            0, 0, 0, 8,  // height
+            1,            // bit depth
+            0,            // color type (grayscale)
+            0, 0, 0       // compression, filter, interlace
+        });
+
+        // 8 scanlines: filter byte 0 + 1 packed byte (8 pixels), alternating rows
+        var raw = new byte[16];
+        for (int y = 0; y < 8; y++)
+        {
+            raw[y * 2] = 0; // filter: none
+            raw[y * 2 + 1] = (byte)(y % 2 == 0 ? 0xAA : 0x55);
+        }
+
+        byte[] compressed;
+        using (var cms = new MemoryStream())
+        {
+            cms.WriteByte(0x78);
+            cms.WriteByte(0x01);
+            using (var deflate = new DeflateStream(cms, CompressionLevel.Fastest, true))
+            {
+                deflate.Write(raw, 0, raw.Length);
+            }
+            uint adler = Adler32(raw);
+            cms.WriteByte((byte)(adler >> 24));
+            cms.WriteByte((byte)(adler >> 16));
+            cms.WriteByte((byte)(adler >> 8));
+            cms.WriteByte((byte)(adler));
+            compressed = cms.ToArray();
+        }
+        WriteChunk(bw, "IDAT", compressed);
         WriteChunk(bw, "IEND", Array.Empty<byte>());
 
         return Convert.ToBase64String(ms.ToArray());

--- a/tests/EggPdf.Tests.Unit/Html/HtmlTokenizerTests.cs
+++ b/tests/EggPdf.Tests.Unit/Html/HtmlTokenizerTests.cs
@@ -23,6 +23,83 @@ public class HtmlTokenizerTests
         tokens.Should().BeEmpty();
     }
 
+    [Theory]
+    [InlineData("&middot;", "·")]
+    [InlineData("&hellip;", "…")]
+    [InlineData("&copy;", "©")]
+    [InlineData("&reg;", "®")]
+    [InlineData("&trade;", "™")]
+    [InlineData("&ndash;", "–")]
+    [InlineData("&mdash;", "—")]
+    [InlineData("&bull;", "•")]
+    [InlineData("&lsquo;", "‘")]
+    [InlineData("&rsquo;", "’")]
+    [InlineData("&ldquo;", "“")]
+    [InlineData("&rdquo;", "”")]
+    [InlineData("&deg;", "°")]
+    [InlineData("&plusmn;", "±")]
+    [InlineData("&laquo;", "«")]
+    [InlineData("&raquo;", "»")]
+    [InlineData("&sect;", "§")]
+    [InlineData("&para;", "¶")]
+    [InlineData("&euro;", "€")]
+    [InlineData("&pound;", "£")]
+    [InlineData("&yen;", "¥")]
+    [InlineData("&cent;", "¢")]
+    [InlineData("&eacute;", "é")]
+    [InlineData("&egrave;", "è")]
+    [InlineData("&agrave;", "à")]
+    [InlineData("&uuml;", "ü")]
+    [InlineData("&ouml;", "ö")]
+    [InlineData("&ntilde;", "ñ")]
+    [InlineData("&ccedil;", "ç")]
+    [InlineData("&szlig;", "ß")]
+    [InlineData("&times;", "×")]
+    [InlineData("&divide;", "÷")]
+    [InlineData("&frac12;", "½")]
+    [InlineData("&iexcl;", "¡")]
+    [InlineData("&iquest;", "¿")]
+    [InlineData("&dagger;", "†")]
+    [InlineData("&Dagger;", "‡")]
+    [InlineData("&permil;", "‰")]
+    [InlineData("&lsaquo;", "‹")]
+    [InlineData("&rsaquo;", "›")]
+    [InlineData("&oelig;", "œ")]
+    [InlineData("&OElig;", "Œ")]
+    [InlineData("&larr;", "←")]
+    [InlineData("&rarr;", "→")]
+    [InlineData("&uarr;", "↑")]
+    [InlineData("&darr;", "↓")]
+    [InlineData("&infin;", "∞")]
+    [InlineData("&ne;", "≠")]
+    [InlineData("&le;", "≤")]
+    [InlineData("&ge;", "≥")]
+    [InlineData("&minus;", "−")]
+    [InlineData("&shy;", "­")]
+    public void NamedEntity_DecodesToUnicodeCharacter(string entity, string expected)
+    {
+        var tokens = Tokenize($"a{entity}b");
+        tokens.Should().HaveCount(1);
+        tokens[0].Data.Should().Be($"a{expected}b");
+    }
+
+    [Fact]
+    public void NamedEntity_LongestMatchWins()
+    {
+        // "&not" is a valid entity (¬), but "&notin;" must match the longer name (∉)
+        var tokens = Tokenize("a&notin;b");
+        tokens.Should().HaveCount(1);
+        tokens[0].Data.Should().Be("a∉b");
+    }
+
+    [Fact]
+    public void UnknownNamedEntity_EmitsAmpersandLiterally()
+    {
+        var tokens = Tokenize("a&bogusentity;b");
+        tokens.Should().HaveCount(1);
+        tokens[0].Data.Should().StartWith("a&");
+    }
+
     [Fact]
     public void PlainText_ReturnsCharacterToken()
     {

--- a/tests/EggPdf.Tests.Unit/Pdf/FlateStreamTests.cs
+++ b/tests/EggPdf.Tests.Unit/Pdf/FlateStreamTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Pdf;
+
+/// <summary>
+/// PDF /FlateDecode streams must be zlib streams (RFC 1950: 2-byte header +
+/// deflate data + Adler-32), not raw deflate — strict viewers reject raw
+/// deflate, which breaks embedded fonts and images.
+/// </summary>
+public class FlateStreamTests
+{
+    private static List<byte[]> ExtractFlateStreams(byte[] pdf)
+    {
+        var result = new List<byte[]>();
+        var text = Encoding.GetEncoding("ISO-8859-1").GetString(pdf);
+
+        // Find dictionaries declaring /FlateDecode followed by a stream
+        foreach (Match m in Regex.Matches(text, @"/Filter /FlateDecode[^>]*>>\s*stream\r?\n"))
+        {
+            int start = m.Index + m.Length;
+            int end = text.IndexOf("endstream", start, StringComparison.Ordinal);
+            if (end < 0) continue;
+            // Trim the trailing newline before "endstream"
+            int len = end - start;
+            while (len > 0 && (pdf[start + len - 1] == (byte)'\n' || pdf[start + len - 1] == (byte)'\r'))
+                len--;
+            var bytes = new byte[len];
+            Array.Copy(pdf, start, bytes, 0, len);
+            result.Add(bytes);
+        }
+        return result;
+    }
+
+    private static uint Adler32(byte[] data)
+    {
+        uint a = 1, b = 0;
+        foreach (byte t in data)
+        {
+            a = (a + t) % 65521;
+            b = (b + a) % 65521;
+        }
+        return (b << 16) | a;
+    }
+
+    [Fact]
+    public async Task EmbeddedFontStreams_AreValidZlib()
+    {
+        // Vietnamese forces CIDFont embedding (FontFile2 + ToUnicode streams)
+        var pdf = await HtmlToPdf.RenderAsync("<html><body><p>Hiệp hội Việt Nam</p></body></html>");
+
+        var streams = ExtractFlateStreams(pdf);
+        streams.Should().NotBeEmpty("an embedded font produces at least FontFile2 and ToUnicode streams");
+
+        foreach (var s in streams)
+        {
+            s.Length.Should().BeGreaterThan(6);
+            (s[0] & 0x0F).Should().Be(8, "zlib CMF low nibble must be 8 (deflate)");
+            (((s[0] << 8) | s[1]) % 31).Should().Be(0, "zlib header must satisfy the FCHECK divisibility rule");
+
+            // Inflate the body (skip 2-byte header, drop 4-byte Adler) and verify checksum
+            byte[] inflated;
+            using (var ms = new MemoryStream(s, 2, s.Length - 6))
+            using (var ds = new DeflateStream(ms, CompressionMode.Decompress))
+            using (var outMs = new MemoryStream())
+            {
+                ds.CopyTo(outMs);
+                inflated = outMs.ToArray();
+            }
+            inflated.Length.Should().BeGreaterThan(0);
+
+            uint expected = Adler32(inflated);
+            uint actual = (uint)((s[s.Length - 4] << 24) | (s[s.Length - 3] << 16) |
+                                 (s[s.Length - 2] << 8) | s[s.Length - 1]);
+            actual.Should().Be(expected, "the trailing 4 bytes must be the Adler-32 of the inflated data");
+        }
+    }
+
+    [Fact]
+    public async Task UppercaseTransformedVietnamese_HasNoNotdefGlyphs()
+    {
+        // text-transform: uppercase is applied at paint time; the codepoint
+        // collection must account for it, otherwise the subset misses the
+        // uppercase glyphs and CID 0 (.notdef) is emitted.
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p style=\"text-transform:uppercase\">Hiệp hội Việt Nam</p></body></html>");
+
+        var text = Encoding.GetEncoding("ISO-8859-1").GetString(pdf);
+        foreach (Match m in Regex.Matches(text, @"<([0-9A-Fa-f]+)>\s*Tj"))
+        {
+            var hex = m.Groups[1].Value;
+            for (int i = 0; i + 4 <= hex.Length; i += 4)
+                hex.Substring(i, 4).Should().NotBe("0000",
+                    "no glyph should degrade to .notdef when the transform is applied consistently");
+        }
+    }
+}

--- a/tests/EggPdf.Tests.Unit/Pdf/PdfSignerTests.cs
+++ b/tests/EggPdf.Tests.Unit/Pdf/PdfSignerTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using EggPdf.Pdf;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Pdf;
+
+/// <summary>
+/// One-call PKI signing: PdfSigner.Sign embeds a detached CMS/PKCS#7 signature
+/// (adbe.pkcs7.detached) with a correct /ByteRange, verifiable by standard
+/// CMS validators.
+/// </summary>
+public class PdfSignerTests
+{
+    private static X509Certificate2 CreateSelfSignedCert()
+    {
+        using var rsa = RSA.Create(2048);
+        var req = new CertificateRequest("CN=EggPdf Test Signer, O=VCRRM",
+            rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null);
+#else
+        return new X509Certificate2(cert.Export(X509ContentType.Pfx));
+#endif
+    }
+
+    [Fact]
+    public async Task Sign_ProducesVerifiableDetachedCms()
+    {
+        var pdf = await HtmlToPdf.RenderAsync("<html><body><p>Signed certificate document</p></body></html>");
+        using var cert = CreateSelfSignedCert();
+
+        var signed = PdfSigner.Sign(pdf, cert, new PdfSigner.SignOptions
+        {
+            Name = "EggPdf Test Signer",
+            Reason = "Approval",
+            Location = "Hanoi"
+        });
+
+        signed.Should().NotBeNull();
+        var text = Encoding.ASCII.GetString(signed);
+
+        // 1. Structure: signature dictionary with real ByteRange
+        text.Should().Contain("/SubFilter /adbe.pkcs7.detached");
+        var brMatch = Regex.Match(text, @"/ByteRange \[(\d+) (\d+) (\d+) (\d+)\]");
+        brMatch.Success.Should().BeTrue("ByteRange must contain real numbers");
+        int r0 = int.Parse(brMatch.Groups[1].Value);
+        int r1 = int.Parse(brMatch.Groups[2].Value);
+        int r2 = int.Parse(brMatch.Groups[3].Value);
+        int r3 = int.Parse(brMatch.Groups[4].Value);
+        r0.Should().Be(0);
+        (r2 + r3).Should().Be(signed.Length, "ranges must cover the file except the Contents hex");
+        r2.Should().BeGreaterThan(r1, "the Contents gap sits between the two ranges");
+
+        // 2. Extract the CMS from /Contents <hex>
+        int hexStart = -1;
+        var cMatch = Regex.Match(text, @"/Contents <([0-9A-Fa-f0]+)>");
+        cMatch.Success.Should().BeTrue();
+        hexStart = cMatch.Groups[1].Index;
+        var hex = cMatch.Groups[1].Value.TrimEnd('0');
+        if (hex.Length % 2 == 1) hex += "0";
+        var cms = new byte[hex.Length / 2];
+        for (int i = 0; i < cms.Length; i++)
+            cms[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+
+        // 3. Verify the signature over the ByteRange content with a real validator
+        var content = new byte[r1 + r3];
+        Array.Copy(signed, r0, content, 0, r1);
+        Array.Copy(signed, r2, content, r1, r3);
+
+        var signedCms = new SignedCms(new ContentInfo(content), detached: true);
+        signedCms.Decode(cms);
+        var act = () => signedCms.CheckSignature(verifySignatureOnly: true);
+        act.Should().NotThrow("the embedded CMS must be cryptographically valid over the ByteRange");
+
+        signedCms.SignerInfos.Count.Should().Be(1);
+        signedCms.Certificates.Count.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public void Sign_NullPdf_ReturnsEmpty()
+    {
+        using var cert = CreateSelfSignedCert();
+        PdfSigner.Sign(null!, cert).Should().BeEmpty();
+    }
+}

--- a/tests/EggPdf.Tests.Unit/Pdf/UnicodeFontEmbeddingTests.cs
+++ b/tests/EggPdf.Tests.Unit/Pdf/UnicodeFontEmbeddingTests.cs
@@ -1,0 +1,82 @@
+using System.Threading.Tasks;
+using EggPdf;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Pdf;
+
+/// <summary>
+/// Tests that text with codepoints outside WinAnsiEncoding (e.g. Vietnamese)
+/// forces TrueType subset embedding instead of falling back to a non-embedded
+/// Type1 font that can only encode Latin-1 (which degrades to '?').
+/// </summary>
+public class UnicodeFontEmbeddingTests
+{
+    private static string Latin1(byte[] pdf)
+    {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        return System.Text.Encoding.GetEncoding("ISO-8859-1").GetString(pdf);
+#else
+        return System.Text.Encoding.Latin1.GetString(pdf);
+#endif
+    }
+
+    [Fact]
+    public async Task Render_VietnameseText_DefaultFont_EmbedsTrueTypeFont()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p>Hiệp hội Công nghiệp Ghi âm Việt Nam</p></body></html>");
+
+        var text = Latin1(pdf);
+        text.Should().Contain("/FontFile2",
+            "Vietnamese text cannot be encoded in WinAnsi, so a TrueType subset must be embedded");
+        text.Should().Contain("/Type0",
+            "embedded Unicode fonts must use the CIDFont Type 2 (Type0) machinery");
+    }
+
+    [Fact]
+    public async Task Render_VietnameseText_ArialFamily_EmbedsTrueTypeFont()
+    {
+        // 'Arial' resolves to a "standard PDF font" name; embedding must still
+        // kick in because the codepoints exceed WinAnsi.
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p style=\"font-family: 'Be Vietnam Pro', 'Segoe UI', Arial, sans-serif\">Giấy Phép Sử Dụng Âm Nhạc</p></body></html>");
+
+        Latin1(pdf).Should().Contain("/FontFile2");
+    }
+
+    [Fact]
+    public async Task Render_VietnameseText_SerifFamily_EmbedsTrueTypeFont()
+    {
+        // Times-Roman path (serif) must also embed when codepoints exceed WinAnsi.
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p style=\"font-family: 'Cormorant Garamond', serif\">Phụ lục Giấy phép</p></body></html>");
+
+        Latin1(pdf).Should().Contain("/FontFile2");
+    }
+
+    [Fact]
+    public async Task Render_AsciiOnlyText_KeepsBuiltinType1Font()
+    {
+        // Pure WinAnsi-encodable text should keep the lean non-embedded built-in
+        // font path (no regression in output size).
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p style=\"font-family: Arial\">Plain ASCII text only</p></body></html>");
+
+        Latin1(pdf).Should().NotContain("/FontFile2");
+    }
+
+    [Fact]
+    public async Task Render_VietnameseText_NoQuestionMarksInContentStream()
+    {
+        // The WinAnsi fallback replaced every Vietnamese diacritic with '?'.
+        // With embedding, content streams use glyph IDs (hex strings), so the
+        // literal "(...?...)" degradation must be gone.
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p>Đơn vị được cấp phép</p></body></html>");
+
+        var text = Latin1(pdf);
+        text.Should().NotContain("n v? ???c",
+            "diacritics must not degrade to '?' in the content stream");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/Text/FontUrlFetcherTests.cs
+++ b/tests/EggPdf.Tests.Unit/Text/FontUrlFetcherTests.cs
@@ -40,4 +40,19 @@ public class FontUrlFetcherTests
     {
         FontUrlFetcher.ParseFontSrcUrl("format('truetype')").Should().BeNull();
     }
+
+    [Fact]
+    public void ParseFontSrcUrl_BareUrlWithFormat_ReturnsUrl()
+    {
+        // The CSS parser unwraps url(...), leaving a bare URL + format(...)
+        FontUrlFetcher.ParseFontSrcUrl("https://fonts.gstatic.com/s/x.ttf format('truetype')")
+            .Should().Be("https://fonts.gstatic.com/s/x.ttf");
+    }
+
+    [Fact]
+    public void ParseFontSrcUrl_BareUrlAlone_ReturnsUrl()
+    {
+        FontUrlFetcher.ParseFontSrcUrl("https://example.com/font.ttf")
+            .Should().Be("https://example.com/font.ttf");
+    }
 }

--- a/tests/EggPdf.Tests.Unit/Text/FontUrlFetcherTests.cs
+++ b/tests/EggPdf.Tests.Unit/Text/FontUrlFetcherTests.cs
@@ -1,0 +1,43 @@
+using EggPdf.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Text;
+
+public class FontUrlFetcherTests
+{
+    [Fact]
+    public void ParseFontSrcUrl_PlainUrl_ReturnsUrl()
+    {
+        FontUrlFetcher.ParseFontSrcUrl("url(https://example.com/font.ttf)")
+            .Should().Be("https://example.com/font.ttf");
+    }
+
+    [Fact]
+    public void ParseFontSrcUrl_UrlWithFormatSuffix_ReturnsUrlOnly()
+    {
+        // Google Fonts CSS emits: src: url(https://...ttf) format('truetype')
+        FontUrlFetcher.ParseFontSrcUrl("url(https://fonts.gstatic.com/s/x.ttf) format('truetype')")
+            .Should().Be("https://fonts.gstatic.com/s/x.ttf");
+    }
+
+    [Fact]
+    public void ParseFontSrcUrl_QuotedUrlWithFormat_ReturnsUrlOnly()
+    {
+        FontUrlFetcher.ParseFontSrcUrl("url(\"https://example.com/font.woff2\") format(\"woff2\")")
+            .Should().Be("https://example.com/font.woff2");
+    }
+
+    [Fact]
+    public void ParseFontSrcUrl_Local_ReturnsLocalPrefix()
+    {
+        FontUrlFetcher.ParseFontSrcUrl("local(\"Segoe UI\")")
+            .Should().Be("local:Segoe UI");
+    }
+
+    [Fact]
+    public void ParseFontSrcUrl_Invalid_ReturnsNull()
+    {
+        FontUrlFetcher.ParseFontSrcUrl("format('truetype')").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- **Chrome print parity for real-world documents**: Vietnamese/Unicode text via embedded webfonts (Google Fonts `<link>` fetching, weight-accurate 300–900 faces, per-codepoint symbol fallback), correct grid/flex positioning (auto margins, `align-items:baseline`, anonymous text items, shrink-to-fit inline-blocks, padding-box containing blocks), browser-style baselines with real font metrics, `word-break:break-all`, NBSP handling, opacity state correctness, 1-bit grayscale PNGs (QR codes), expanded named entities, Cloudflare `data-cfemail` decoding
- **Critical PDF-writer fixes**: `/FlateDecode` streams are now valid zlib (raw deflate broke embedded fonts/images in strict viewers); cmap format 12 parsing; format-4 subset cmaps split on glyph-run boundaries
- **NEW: one-call PKI signing** — `PdfSigner.Sign(pdf, X509Certificate2)` embeds a detached CMS/PKCS#7 signature with a valid `/ByteRange`, via a hand-rolled RFC 5652 encoder (zero NuGet deps); docs synced (fonts/webfonts page, `/api/encrypt` + `/api/sign` REST docs, llms.txt security section)

Verified end-to-end against Chrome's print output for the VCRRM certificate: element-by-element parity including backgrounds, fonts, line breaks, QR, stamps, and footers.

## Test Evidence
- **1,519 tests pass** (965 unit + 554 layout; ~110 new this branch, 0 failing)
- Every fix has a dedicated regression test written first (17 new test classes: fonts/webfonts, weights, zlib validity, opacity leak, grid/flex positioning, baselines, break-all, NBSP, shrink-to-fit, auto margins, glyph fallback, cfemail, signing)
- Signing validated against the reference `SignedCms` verifier over the real ByteRange (test-only Pkcs package)

## Performance
| Scenario | Time | Memory | Target | Status |
|----------|------|--------|--------|--------|
| Simple page (h1 + p) | 47.6 µs | ~20 KB | < 50 ms | ✅ |
| Invoice (table + styles) | 585 µs | ~85 KB | < 100 ms | ✅ |
| Large table (100 rows) | 5.8 ms | ~939 KB | < 5 s | ✅ |

Same-machine A/B against `main` baseline: within run-to-run variance. No performance regressions detected. (Webfont/measurement providers only activate when `@font-face` is present — zero overhead for plain documents.)

## Checklist
- [x] Tests written FIRST, then implementation
- [x] All tests pass (new + existing)
- [x] No performance regression
- [x] Public API has XML documentation
- [x] Multi-target compatible (netstandard2.0+ compile verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)