### PR TITLE
fix: font-cache failure retry, single-pass whitespace collapse, real version in /health

### DIFF
--- a/src/EggPdf.Layout/BlockLayout.cs
+++ b/src/EggPdf.Layout/BlockLayout.cs
@@ -1370,6 +1370,48 @@ public static class BlockLayout
         return text; // capitalize changes width negligibly
     }
 
+    /// <summary>
+    /// CSS white-space:normal collapsing for an inline run: \n \r \t map to
+    /// spaces, runs of ordinary spaces collapse to one, edge whitespace trims.
+    /// NBSP is rendered content — trimmed at the edges (like string.Trim did)
+    /// but never collapsed in the interior. Zero-allocation when the text is
+    /// already normalized.
+    /// </summary>
+    private static string NormalizeInlineWhitespace(string text)
+    {
+        int start = 0, end = text.Length;
+        while (start < end && char.IsWhiteSpace(text[start])) start++;
+        while (end > start && char.IsWhiteSpace(text[end - 1])) end--;
+        if (start >= end) return "";
+
+        bool needsRewrite = false;
+        for (int i = start; i < end; i++)
+        {
+            char c = text[i];
+            if (c == '\n' || c == '\r' || c == '\t' ||
+                (c == ' ' && text[i - 1] == ' '))
+            {
+                needsRewrite = true;
+                break;
+            }
+        }
+
+        if (!needsRewrite)
+            return start == 0 && end == text.Length ? text : text.Substring(start, end - start);
+
+        var sb = new System.Text.StringBuilder(end - start);
+        bool prevSpace = false;
+        for (int i = start; i < end; i++)
+        {
+            char c = text[i];
+            if (c == '\n' || c == '\r' || c == '\t') c = ' ';
+            if (c == ' ' && prevSpace) continue;
+            sb.Append(c);
+            prevSpace = c == ' ';
+        }
+        return sb.ToString();
+    }
+
     /// <summary>Walk up parent chain to find page height.</summary>
     private static float FindPageHeight(LayoutBox parent)
     {
@@ -2503,14 +2545,12 @@ public static class BlockLayout
                 continue;
             }
 
-            // Normalize whitespace
-            var text = run.Text.Replace('\n', ' ').Replace('\r', ' ').Replace('\t', ' ');
-            // Collapse multiple spaces
-            while (text.IndexOf("  ", StringComparison.Ordinal) >= 0)
-                text = text.Replace("  ", " ");
-            text = text.Trim();
+            // Normalize whitespace: \n \r \t become spaces, runs of spaces
+            // collapse, edges trim — single pass (the old Replace loop
+            // reallocated the string once per collapsed pair).
+            var text = NormalizeInlineWhitespace(run.Text);
 
-            if (string.IsNullOrEmpty(text)) continue;
+            if (text.Length == 0) continue;
 
             // Measure the transformed text (uppercase is wider); the paint-time
             // transform is idempotent so word boxes may carry it too.

--- a/src/EggPdf.Service/Program.cs
+++ b/src/EggPdf.Service/Program.cs
@@ -19,7 +19,7 @@ app.UseStaticFiles();
 app.MapGet("/health", () => Results.Ok(new
 {
     status = "healthy",
-    version = "0.1.0",
+    version = typeof(EggPdf.HtmlToPdf).Assembly.GetName().Version?.ToString(3) ?? "unknown",
     uptime = (DateTime.UtcNow - Process.GetCurrentProcess().StartTime.ToUniversalTime()).ToString(@"d\.hh\:mm\:ss")
 }));
 

--- a/src/EggPdf.Service/wwwroot/index.html
+++ b/src/EggPdf.Service/wwwroot/index.html
@@ -109,7 +109,7 @@
 <header class="header">
   <div class="logo">
     <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><rect width="24" height="24" rx="6" fill="#6c5ce7"/><path d="M7 7h10v2H7V7zm0 4h10v2H7v-2zm0 4h7v2H7v-2z" fill="white"/></svg>
-    EggPdf <span>v0.1.0</span>
+    EggPdf <span id="appVersion"></span>
   </div>
   <div class="tabs">
     <button class="tab active" onclick="switchEditorTab('html', this)">HTML</button>
@@ -773,6 +773,11 @@ async function downloadPdfFile() {
     window.open(url, '_blank');
   } catch (e) { alert('Download error: ' + e.message); }
 }
+
+// Header version badge follows the running engine, not a hardcoded string
+fetch('/api/info').then(r => r.json())
+  .then(info => { document.getElementById('appVersion').textContent = 'v' + info.version; })
+  .catch(() => {});
 </script>
 </body>
 </html>

--- a/src/EggPdf.Text/EggPdf.Text.csproj
+++ b/src/EggPdf.Text/EggPdf.Text.csproj
@@ -11,4 +11,8 @@
     <ProjectReference Include="..\EggPdf.Core\EggPdf.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="EggPdf.Tests.Unit" />
+  </ItemGroup>
+
 </Project>

--- a/src/EggPdf.Text/FontUrlFetcher.cs
+++ b/src/EggPdf.Text/FontUrlFetcher.cs
@@ -12,8 +12,20 @@ namespace EggPdf.Text;
 /// </summary>
 public static class FontUrlFetcher
 {
-    private static readonly ConcurrentDictionary<string, byte[]?> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, byte[]> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, DateTime> _failedFetches = new(StringComparer.OrdinalIgnoreCase);
     private static readonly HttpClient _httpClient = CreateClient();
+
+    /// <summary>
+    /// How long a failed fetch suppresses retries for that URL. Bounded so a
+    /// transient network failure cannot poison the URL for the process
+    /// lifetime, but long enough that a dead URL does not add a network
+    /// timeout to every render. Internal-mutable for tests.
+    /// </summary>
+    internal static TimeSpan FailureRetryInterval = TimeSpan.FromSeconds(30);
+
+    /// <summary>Test seam: replaces the actual fetch when set.</summary>
+    internal static Func<string, byte[]?>? FetchOverride;
 
     private static HttpClient CreateClient()
     {
@@ -31,17 +43,34 @@ public static class FontUrlFetcher
     {
         if (string.IsNullOrEmpty(url)) return null;
 
-        return _cache.GetOrAdd(url, u =>
+        if (_cache.TryGetValue(url, out var cached)) return cached;
+
+        // A recent failure suppresses retries briefly; unlike a cache entry
+        // it expires, so the URL recovers after a transient outage.
+        if (_failedFetches.TryGetValue(url, out var failedAt) &&
+            DateTime.UtcNow - failedAt < FailureRetryInterval)
+            return null;
+
+        byte[]? data;
+        try
         {
-            try
-            {
-                return FetchInternal(u);
-            }
-            catch
-            {
-                return null;
-            }
-        });
+            var fetch = FetchOverride;
+            data = fetch != null ? fetch(url) : FetchInternal(url);
+        }
+        catch
+        {
+            data = null;
+        }
+
+        if (data != null && data.Length > 0)
+        {
+            _cache.TryAdd(url, data);
+            _failedFetches.TryRemove(url, out _);
+            return data;
+        }
+
+        _failedFetches[url] = DateTime.UtcNow;
+        return null;
     }
 
     private static byte[]? FetchInternal(string url)
@@ -124,6 +153,10 @@ public static class FontUrlFetcher
         return null;
     }
 
-    /// <summary>Clear the font cache.</summary>
-    public static void ClearCache() => _cache.Clear();
+    /// <summary>Clear the font cache, including recorded fetch failures.</summary>
+    public static void ClearCache()
+    {
+        _cache.Clear();
+        _failedFetches.Clear();
+    }
 }

--- a/src/EggPdf/HtmlToPdf.cs
+++ b/src/EggPdf/HtmlToPdf.cs
@@ -734,13 +734,20 @@ public static class HtmlToPdf
                 {
                     // Parse once per process — fetched bytes are cached by URL,
                     // but reparsing every render costs tens of ms per face.
-                    fontData = WebFontParseCache.GetOrAdd(url, u =>
+                    if (!WebFontParseCache.TryGetValue(url, out fontData))
                     {
-                        var rawBytes = Text.FontUrlFetcher.Fetch(u);
-                        if (rawBytes == null || rawBytes.Length == 0) return null;
-                        try { return Text.TrueType.TtfParser.Parse(rawBytes); }
-                        catch { return null; }
-                    });
+                        var rawBytes = Text.FontUrlFetcher.Fetch(url);
+                        if (rawBytes != null && rawBytes.Length != 0)
+                        {
+                            try { fontData = Text.TrueType.TtfParser.Parse(rawBytes); }
+                            catch { fontData = null; }
+                            // The bytes behind a URL are immutable once fetched, so
+                            // even a parse failure is safe to cache. A FAILED fetch
+                            // is not cached here — FontUrlFetcher's retry window
+                            // decides when that URL may be tried again.
+                            WebFontParseCache.TryAdd(url, fontData);
+                        }
+                    }
                 }
 
                 if (fontData != null) return fontData;

--- a/tests/EggPdf.Tests.Unit/EndToEnd/WhitespaceCollapseTests.cs
+++ b/tests/EggPdf.Tests.Unit/EndToEnd/WhitespaceCollapseTests.cs
@@ -1,0 +1,51 @@
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.EndToEnd;
+
+/// <summary>
+/// Runs of spaces, tabs, and newlines inside a text run must collapse to a
+/// single space (CSS white-space: normal). Guards the single-pass rewrite of
+/// the old Replace-in-a-loop collapse in BlockLayout.
+/// </summary>
+public class WhitespaceCollapseTests
+{
+    [Fact]
+    public async Task ConsecutiveSpacesTabsNewlines_CollapseToSingleSpace()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p>alpha  \t\n  beta      gamma</p></body></html>");
+        var text = Encoding.ASCII.GetString(pdf);
+
+        // Adjacent word boxes of one run merge into a single text op
+        text.Should().Contain("(alpha beta gamma)",
+            "runs of mixed whitespace collapse to single spaces");
+    }
+
+    [Fact]
+    public async Task LeadingAndTrailingWhitespace_IsTrimmedFromTheRun()
+    {
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p>\n\t  hello  \t\n</p></body></html>");
+        var text = Encoding.ASCII.GetString(pdf);
+
+        text.Should().Contain("(hello)", "edge whitespace of a block's text is trimmed");
+        text.Should().NotContain("( hello)");
+    }
+
+    [Fact]
+    public async Task InteriorNbsp_IsPreservedNotCollapsed()
+    {
+        // NBSP is rendered content, not collapsible whitespace: "a&nbsp;&nbsp;b"
+        // keeps both NBSPs while surrounding ASCII spaces still collapse.
+        var pdf = await HtmlToPdf.RenderAsync(
+            "<html><body><p>a&#160;&#160;b   c</p></body></html>");
+        var text = Encoding.GetEncoding("ISO-8859-1").GetString(pdf);
+
+        var nbsp = (char)0x00A0; // named char keeps this source file pure ASCII
+        text.Should().Contain("(a" + nbsp + nbsp + "b c)",
+            "interior non-breaking spaces are content while ASCII space runs collapse");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/Text/FontUrlFetcherRetryTests.cs
+++ b/tests/EggPdf.Tests.Unit/Text/FontUrlFetcherRetryTests.cs
@@ -1,0 +1,97 @@
+using System;
+using EggPdf.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Text;
+
+/// <summary>
+/// A transient network failure must not poison a font URL for the process
+/// lifetime — failures may only suppress retries for a bounded window,
+/// while successful fetches stay cached forever (font URLs are immutable).
+/// </summary>
+public class FontUrlFetcherRetryTests
+{
+    private static readonly byte[] FakeFont = { 0x00, 0x01, 0x00, 0x00 };
+
+    [Fact]
+    public void Fetch_FailureThenSuccess_RetriesInsteadOfPoisoningCache()
+    {
+        var url = "https://retry-test.example/failure-then-success.ttf";
+        int calls = 0;
+        var oldInterval = FontUrlFetcher.FailureRetryInterval;
+        FontUrlFetcher.FetchOverride = _ => ++calls == 1 ? null : FakeFont;
+        FontUrlFetcher.FailureRetryInterval = TimeSpan.Zero;
+        try
+        {
+            FontUrlFetcher.Fetch(url).Should().BeNull("the first fetch fails");
+            FontUrlFetcher.Fetch(url).Should().Equal(FakeFont,
+                "a failed fetch must be retried once the retry window elapses");
+        }
+        finally
+        {
+            FontUrlFetcher.FetchOverride = null;
+            FontUrlFetcher.FailureRetryInterval = oldInterval;
+        }
+    }
+
+    [Fact]
+    public void Fetch_Success_IsCachedAndNotRefetched()
+    {
+        var url = "https://retry-test.example/success-cached.ttf";
+        int calls = 0;
+        FontUrlFetcher.FetchOverride = _ => { calls++; return FakeFont; };
+        try
+        {
+            FontUrlFetcher.Fetch(url).Should().Equal(FakeFont);
+            FontUrlFetcher.Fetch(url).Should().Equal(FakeFont);
+            calls.Should().Be(1, "a successful fetch is cached for the process lifetime");
+        }
+        finally
+        {
+            FontUrlFetcher.FetchOverride = null;
+        }
+    }
+
+    [Fact]
+    public void Fetch_FailureWithinRetryWindow_DoesNotHammerTheUrl()
+    {
+        var url = "https://retry-test.example/failure-suppressed.ttf";
+        int calls = 0;
+        var oldInterval = FontUrlFetcher.FailureRetryInterval;
+        FontUrlFetcher.FetchOverride = _ => { calls++; return null; };
+        FontUrlFetcher.FailureRetryInterval = TimeSpan.FromHours(1);
+        try
+        {
+            FontUrlFetcher.Fetch(url).Should().BeNull();
+            FontUrlFetcher.Fetch(url).Should().BeNull();
+            calls.Should().Be(1,
+                "within the retry window a known-bad URL must not add a network timeout to every render");
+        }
+        finally
+        {
+            FontUrlFetcher.FetchOverride = null;
+            FontUrlFetcher.FailureRetryInterval = oldInterval;
+        }
+    }
+
+    [Fact]
+    public void Fetch_EmptyPayload_IsTreatedAsFailureAndRetried()
+    {
+        var url = "https://retry-test.example/empty-then-success.ttf";
+        int calls = 0;
+        var oldInterval = FontUrlFetcher.FailureRetryInterval;
+        FontUrlFetcher.FetchOverride = _ => ++calls == 1 ? new byte[0] : FakeFont;
+        FontUrlFetcher.FailureRetryInterval = TimeSpan.Zero;
+        try
+        {
+            FontUrlFetcher.Fetch(url).Should().BeNull("an empty font file is not usable");
+            FontUrlFetcher.Fetch(url).Should().Equal(FakeFont);
+        }
+        finally
+        {
+            FontUrlFetcher.FetchOverride = null;
+            FontUrlFetcher.FailureRetryInterval = oldInterval;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Perf-review follow-ups to the v1.4.1 font-caching work:

- **fix: negative font-cache poisoning** — a transient network failure on the first fetch of a webfont URL was cached as permanent failure (both in `FontUrlFetcher` and the parse cache), silently degrading every subsequent render to fallback fonts until process restart. Failures now suppress retries for a bounded 30s window and then expire; successes stay cached for the process lifetime as before.
- **perf: single-pass whitespace collapse** in `BlockLayout` inline runs — replaces the `Replace("  ", " ")` loop that reallocated once per collapsed pair (O(n²) on long space runs) and three unconditional `Replace` calls per run. Zero-allocation when text is already normalized. NBSP semantics unchanged (covered by new tests).
- **fix: `/health` and WebUI header reported hardcoded `0.1.0`** — both now follow the real assembly version (`/api/info` already did).

## Test evidence
- Unit: **972/972 passed** (7 new: 4 fetch-retry, 3 whitespace-collapse/NBSP regression)
- Layout: **554/554 passed**

## Perf evidence (short job, branch vs main worktree, same machine)
| Scenario | main | this branch | Allocated |
|---|---|---|---|
| Simple page | 56.8 us | 51.1 us | 35.5 KB (identical) |
| Invoice | 968 us | 1,046 us (within ±110 us error) | 353.31 KB (identical) |
| Large table | 20.6 ms | 12.3 ms (noisy machine) | 1,717 KB (identical) |

No regression: allocations byte-identical, times within short-job error bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)