### PR TITLE
test: decode compressed content streams in E2E PDF-text assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,8 @@ ipch/
 
 # Visual Studio Trace Files
 *.e2e
+# ...but *.e2e also matches the E2E test project directory — keep it tracked
+!tests/EggPdf.Tests.E2E/
 
 # TFS 2012 Local Workspace
 $tf/

--- a/tests/EggPdf.Tests.E2E/ApiEndpointTests.cs
+++ b/tests/EggPdf.Tests.E2E/ApiEndpointTests.cs
@@ -104,7 +104,7 @@ public class ApiEndpointTests
 
         resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var bytes = await resp.Content.ReadAsByteArrayAsync();
-        var pdfText = Encoding.ASCII.GetString(bytes);
+        var pdfText = PdfTextDecoder.Decode(bytes);
         pdfText.Should().Contain("Invoice");
         pdfText.Should().Contain("Widget");
     }

--- a/tests/EggPdf.Tests.E2E/PdfTextDecoder.cs
+++ b/tests/EggPdf.Tests.E2E/PdfTextDecoder.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace EggPdf.Tests.E2E;
+
+/// <summary>
+/// Decodes a rendered PDF to assertable text: Latin-1 for the object
+/// structure, with every FlateDecode stream inflated in place so tests can
+/// assert on content-stream operators regardless of compression (page content
+/// streams are FlateDecode-compressed by default since v1.4.3).
+/// </summary>
+public static class PdfTextDecoder
+{
+    public static string Decode(byte[] pdf)
+    {
+        var text = Encoding.Latin1.GetString(pdf); // Latin-1 maps chars to bytes 1:1
+        var sb = new StringBuilder(text.Length * 2);
+        int pos = 0;
+
+        while (true)
+        {
+            int filterIdx = text.IndexOf("/FlateDecode", pos, StringComparison.Ordinal);
+            if (filterIdx < 0) break;
+            int streamIdx = text.IndexOf("stream\n", filterIdx, StringComparison.Ordinal);
+            if (streamIdx < 0) break;
+            int dataStart = streamIdx + "stream\n".Length;
+            int endIdx = text.IndexOf("endstream", dataStart, StringComparison.Ordinal);
+            if (endIdx < 0) break;
+
+            int dataEnd = endIdx;
+            while (dataEnd > dataStart && (text[dataEnd - 1] == '\n' || text[dataEnd - 1] == '\r'))
+                dataEnd--;
+
+            sb.Append(text, pos, dataStart - pos);
+            try
+            {
+                var raw = new byte[dataEnd - dataStart];
+                for (int i = 0; i < raw.Length; i++) raw[i] = (byte)text[dataStart + i];
+                // Skip the 2-byte zlib header; DeflateStream stops before the Adler-32.
+                using var input = new MemoryStream(raw, 2, raw.Length - 2);
+                using var deflate = new DeflateStream(input, CompressionMode.Decompress);
+                using var output = new MemoryStream();
+                deflate.CopyTo(output);
+                sb.Append(Encoding.Latin1.GetString(output.ToArray()));
+            }
+            catch
+            {
+                sb.Append(text, dataStart, dataEnd - dataStart); // leave undecodable data as-is
+            }
+            sb.Append(text, dataEnd, endIdx - dataEnd);
+            pos = endIdx;
+        }
+
+        sb.Append(text, pos, text.Length - pos);
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## Summary
PR #211 turned on content-stream compression by default, which broke `ApiEndpointTests.Render_ComplexHtml_ReturnsPdf` on main (it asserts on raw PDF bytes). This PR:

- adds `PdfTextDecoder` — Latin-1 decode with every FlateDecode stream inflated in place — and routes the E2E PDF-text assertion through it
- fixes a `.gitignore` landmine: the stock VS rule `*.e2e` (trace files) also matches the directory `tests/EggPdf.Tests.E2E`, so new E2E test files were silently unversioned; added a `!tests/EggPdf.Tests.E2E/` negation

Verified locally against the live compressing service: all tracked E2E tests pass and the decoder exposes inflated operators for assertion.

Main is currently red on `.NET 10 Build & Test` because of this one test; this fixes it forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)