### PR TITLE
fix: RC4-encrypt streams and strings so PDF encryption actually works end-to-end

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -186,7 +186,7 @@ netstandard2.0, netstandard2.1, net6.0, net8.0, net9.0, net10.0
 - Repeating table headers
 - TrueType/OpenType embedding with subsetting
 - Digital signatures: one-call X.509 signing (detached CMS/PKCS#7, adbe.pkcs7.detached) or external-CMS two-step flow
-- Encryption: RC4 40/128-bit with owner/user passwords and permission flags (via REST /api/encrypt)
+- Encryption: RC4 40/128-bit with owner/user passwords and permission flags — one-call `HtmlToPdf.Render(html, new PdfEncryption {...})` or REST /api/encrypt; all streams and strings encrypted per the PDF 1.7 Standard security handler
 - Cloudflare email obfuscation (data-cfemail) decoded automatically
 - PDF merging
 
@@ -210,7 +210,20 @@ byte[] done = PdfSigner.SignWithCmsData(withPlaceholder, cmsBytes);
 ```
 
 View-only protection (RC4 40/128-bit, owner/user passwords, permission flags —
-printing/copying/modifying) is available through the REST service:
+printing/copying/modifying). One call in code:
+
+```csharp
+byte[] protectedPdf = HtmlToPdf.Render(html, new PdfEncryption
+{
+    OwnerPassword = "secret",     // full access
+    UserPassword = "",            // empty = opens without a prompt, permissions still apply
+    AllowPrinting = true,
+    AllowCopying = false,
+    AllowModifying = false,
+});
+```
+
+Or through the REST service:
 
 ```bash
 curl -X POST http://localhost:8080/api/encrypt \

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -54,7 +54,7 @@ curl -X POST http://localhost:8080/api/render \
 byte[] signed = EggPdf.Pdf.PdfSigner.Sign(pdf, x509CertWithPrivateKey,
     new EggPdf.Pdf.PdfSigner.SignOptions { Name = "Jane", Reason = "Approval" });
 ```
-- View-only PDFs via REST `POST /api/encrypt` (RC4 128-bit, owner/user passwords, print/copy/modify flags)
+- View-only PDFs: `HtmlToPdf.Render(html, new PdfEncryption {...})` or REST `POST /api/encrypt` (RC4 128-bit, owner/user passwords, print/copy/modify flags)
 - Permission flags are advisory; signatures give cryptographic tamper evidence
 
 ## Performance

--- a/src/EggPdf.Pdf/PdfDocument.cs
+++ b/src/EggPdf.Pdf/PdfDocument.cs
@@ -131,6 +131,18 @@ public class PdfDocument
     {
         var writer = new PdfStreamWriter(output);
 
+        // Encryption: compute the file key up front — every stream and string
+        // below is RC4-encrypted with a per-object key derived from it.
+        EncryptionParams? enc = null;
+        byte[] encDocId = Array.Empty<byte>();
+        if (Encryption != null &&
+            (!string.IsNullOrEmpty(Encryption.OwnerPassword) || !string.IsNullOrEmpty(Encryption.UserPassword)))
+        {
+            using (var md5 = System.Security.Cryptography.MD5.Create())
+                encDocId = md5.ComputeHash(Encoding.UTF8.GetBytes(DateTime.UtcNow.Ticks.ToString() + (Title ?? "")));
+            enc = Encryption.Compute(encDocId);
+        }
+
         // Header
         writer.WriteLine("%PDF-1.7");
         writer.WriteLine("%\xE2\xE3\xCF\xD3"); // binary marker
@@ -242,7 +254,7 @@ public class PdfDocument
             if (cidFontObjs.TryGetValue(kv.Key, out var cid))
             {
                 // Write CIDFont Type 2 (embedded TrueType)
-                WriteCIDFont(writer, offsets, kv.Key, cid, _embeddedFonts[kv.Key]);
+                WriteCIDFont(writer, offsets, kv.Key, cid, _embeddedFonts[kv.Key], enc);
             }
             else
             {
@@ -285,7 +297,7 @@ public class PdfDocument
             var img = _images[kv.Key];
             var smaskData = img.SMaskData!;
 
-            byte[] compressedSmask = CompressZlib(smaskData);
+            byte[] compressedSmask = EncryptBytes(enc, CompressZlib(smaskData), kv.Value);
 
             offsets[kv.Value] = writer.Position;
             writer.WriteLine($"{kv.Value} 0 obj");
@@ -309,21 +321,22 @@ public class PdfDocument
             if (img.Format == PdfImageFormat.Jpeg)
             {
                 // JPEG: pass-through with DCTDecode
+                byte[] jpegBody = EncryptBytes(enc, img.Data, kv.Value);
                 var imgDict = new StringBuilder();
                 imgDict.Append($"<< /Type /XObject /Subtype /Image /Width {img.Width} /Height {img.Height}");
                 imgDict.Append($" /ColorSpace /DeviceRGB /BitsPerComponent {img.BitsPerComponent}");
-                imgDict.Append($" /Filter /DCTDecode /Length {img.Data.Length}");
+                imgDict.Append($" /Filter /DCTDecode /Length {jpegBody.Length}");
                 imgDict.Append(" >>");
                 writer.WriteLine(imgDict.ToString());
                 writer.WriteLine("stream");
-                writer.WriteBytes(img.Data);
+                writer.WriteBytes(jpegBody);
                 writer.WriteLine("");
                 writer.WriteLine("endstream");
             }
             else
             {
                 // Raw RGB: compress with zlib (FlateDecode)
-                byte[] compressed = CompressZlib(img.Data);
+                byte[] compressed = EncryptBytes(enc, CompressZlib(img.Data), kv.Value);
 
                 var imgDict = new StringBuilder();
                 imgDict.Append($"<< /Type /XObject /Subtype /Image /Width {img.Width} /Height {img.Height}");
@@ -371,16 +384,17 @@ public class PdfDocument
             writer.WriteLine($"{contentStreamObj} 0 obj");
             if (CompressContentStreams)
             {
-                var compressedContent = CompressZlib(contentBytes);
+                var compressedContent = EncryptBytes(enc, CompressZlib(contentBytes), contentStreamObj);
                 writer.WriteLine($"<< /Length {compressedContent.Length} /Filter /FlateDecode >>");
                 writer.WriteLine("stream");
                 writer.WriteBytes(compressedContent);
             }
             else
             {
-                writer.WriteLine($"<< /Length {contentBytes.Length} >>");
+                var contentBody = EncryptBytes(enc, contentBytes, contentStreamObj);
+                writer.WriteLine($"<< /Length {contentBody.Length} >>");
                 writer.WriteLine("stream");
-                writer.WriteBytes(contentBytes);
+                writer.WriteBytes(contentBody);
             }
             writer.WriteLine("");
             writer.WriteLine("endstream");
@@ -444,7 +458,7 @@ public class PdfDocument
                     float y2 = link.Y + link.Height;
                     pageDict.Append($" << /Type /Annot /Subtype /Link /Rect [{F(x1)} {F(y1)} {F(x2)} {F(y2)}]");
                     pageDict.Append($" /Border [0 0 0]");
-                    pageDict.Append($" /A << /Type /Action /S /URI /URI ({EscapePdfString(link.Url)}) >> >>");
+                    pageDict.Append($" /A << /Type /Action /S /URI /URI {PdfString(enc, link.Url, pageDictObj)} >> >>");
                 }
                 pageDict.Append(" ]");
             }
@@ -457,19 +471,19 @@ public class PdfDocument
         // Write outline objects (bookmarks)
         if (_bookmarks != null && _bookmarks.Count > 0 && outlineRootObj > 0)
         {
-            WriteOutlineObjects(writer, offsets, pageObjs, outlineRootObj, outlineItemObjs);
+            WriteOutlineObjects(writer, offsets, pageObjs, outlineRootObj, outlineItemObjs, enc);
         }
 
         // Info dictionary
         offsets[infoObj] = writer.Position;
         writer.WriteLine($"{infoObj} 0 obj");
         var info = new StringBuilder();
-        info.Append("<< /Producer (EggPdf)");
+        info.Append($"<< /Producer {PdfString(enc, "EggPdf", infoObj)}");
         if (!string.IsNullOrEmpty(Title))
-            info.Append($" /Title ({EscapePdfString(Title)})");
+            info.Append($" /Title {PdfString(enc, Title!, infoObj)}");
         if (!string.IsNullOrEmpty(Author))
-            info.Append($" /Author ({EscapePdfString(Author)})");
-        info.Append($" /CreationDate (D:{DateTime.UtcNow:yyyyMMddHHmmss}Z)");
+            info.Append($" /Author {PdfString(enc, Author!, infoObj)}");
+        info.Append($" /CreationDate {PdfString(enc, $"D:{DateTime.UtcNow:yyyyMMddHHmmss}Z", infoObj)}");
         info.Append(" >>");
         writer.WriteLine(info.ToString());
         writer.WriteLine("endobj");
@@ -494,21 +508,15 @@ public class PdfDocument
         var trailerDict = new StringBuilder();
         trailerDict.Append($"<< /Size {totalObjects} /Root {catalogObj} 0 R /Info {infoObj} 0 R");
 
-        // Add encryption dictionary if configured
-        if (Encryption != null && !string.IsNullOrEmpty(Encryption.OwnerPassword))
+        // Add encryption dictionary if configured — reuses the parameters the
+        // streams and strings above were actually encrypted with.
+        if (enc != null)
         {
-            // Generate document ID
-            var docId = new byte[16];
-            using (var md5 = System.Security.Cryptography.MD5.Create())
-            {
-                var idSource = Encoding.UTF8.GetBytes(DateTime.UtcNow.Ticks.ToString() + (Title ?? ""));
-                docId = md5.ComputeHash(idSource);
-            }
-            var encParams = Encryption.Compute(docId);
+            var encParams = enc;
 
             string oHex = BitConverter.ToString(encParams.OValue).Replace("-", "");
             string uHex = BitConverter.ToString(encParams.UValue).Replace("-", "");
-            string idHex = BitConverter.ToString(docId).Replace("-", "");
+            string idHex = BitConverter.ToString(encDocId).Replace("-", "");
 
             trailerDict.Append($" /ID [<{idHex}> <{idHex}>]");
             trailerDict.Append($" /Encrypt << /Filter /Standard /V 2 /R 3 /Length {encParams.KeyLength}");
@@ -534,7 +542,8 @@ public class PdfDocument
         Dictionary<int, long> offsets,
         List<(int pageDict, int contentStream, int? annotArray)> pageObjs,
         int outlineRootObj,
-        List<int> outlineItemObjs)
+        List<int> outlineItemObjs,
+        EncryptionParams? enc)
     {
         // Build tree structure from flat list:
         // Each node tracks: parentObjId, firstChildIdx, lastChildIdx, prevIdx, nextIdx, childCount
@@ -640,9 +649,8 @@ public class PdfDocument
             int pageRef = pageObjs[pageIdx].pageDict;
 
             var entry = new StringBuilder();
-            entry.Append("<< /Title (");
-            entry.Append(EscapePdfString(bm.Title));
-            entry.Append(")");
+            entry.Append("<< /Title ");
+            entry.Append(PdfString(enc, bm.Title, objNum));
             entry.Append($" /Parent {parentObj[i]} 0 R");
             entry.Append($" /Dest [{pageRef} 0 R /XYZ 0 {F(bm.TopPt)} 0]");
 
@@ -713,10 +721,10 @@ public class PdfDocument
     /// <summary>Write a CIDFont Type 2 (embedded TrueType) with all required objects.</summary>
     private void WriteCIDFont(PdfStreamWriter writer, Dictionary<int, long> offsets,
         string fontName, (int type0, int cidFont, int descriptor, int stream, int toUnicode) objs,
-        EmbeddedFontData fontData)
+        EmbeddedFontData fontData, EncryptionParams? enc)
     {
-        // 1. Compress the subset font data
-        byte[] compressed = CompressZlib(fontData.SubsetData);
+        // 1. Compress the subset font data (encrypt after compressing)
+        byte[] compressed = EncryptBytes(enc, CompressZlib(fontData.SubsetData), objs.stream);
 
         // 2. Build W (widths) array: /W [0 [w0 w1 w2 ...]]
         var wArray = new StringBuilder();
@@ -733,7 +741,7 @@ public class PdfDocument
         // 3. Build ToUnicode CMap
         byte[] toUnicodeData = BuildToUnicodeCMap(fontData.CodepointToGlyphId);
 
-        byte[] toUnicodeCompressed = CompressZlib(toUnicodeData);
+        byte[] toUnicodeCompressed = EncryptBytes(enc, CompressZlib(toUnicodeData), objs.toUnicode);
 
         // 4. Write font stream (subset TrueType data)
         offsets[objs.stream] = writer.Position;
@@ -763,7 +771,7 @@ public class PdfDocument
         offsets[objs.cidFont] = writer.Position;
         writer.WriteLine($"{objs.cidFont} 0 obj");
         writer.WriteLine($"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /{fontName}");
-        writer.WriteLine($"/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >>");
+        writer.WriteLine($"/CIDSystemInfo << /Registry {PdfString(enc, "Adobe", objs.cidFont)} /Ordering {PdfString(enc, "Identity", objs.cidFont)} /Supplement 0 >>");
         writer.WriteLine($"/FontDescriptor {objs.descriptor} 0 R");
         writer.WriteLine($"/W {wArray}");
         writer.WriteLine($"/DW 1000 >>");
@@ -850,6 +858,27 @@ public class PdfDocument
 
     private static string EscapePdfString(string text)
         => text.Replace("\\", "\\\\").Replace("(", "\\(").Replace(")", "\\)");
+
+    /// <summary>Encrypt stream bytes for their containing object (no-op when unencrypted).</summary>
+    private static byte[] EncryptBytes(EncryptionParams? enc, byte[] data, int objNum)
+        => enc == null ? data : PdfEncryption.EncryptForObject(enc.EncryptionKey, objNum, 0, data);
+
+    /// <summary>
+    /// Serialize a PDF string for the given containing object: a literal
+    /// (escaped) string when unencrypted, an RC4-encrypted hex string when
+    /// the document is encrypted (spec: ALL strings are encrypted).
+    /// </summary>
+    private static string PdfString(EncryptionParams? enc, string text, int objNum)
+    {
+        if (enc == null) return "(" + EscapePdfString(text) + ")";
+
+        var cipher = PdfEncryption.EncryptForObject(enc.EncryptionKey, objNum, 0, Latin1Encoding.GetBytes(text));
+        var sb = new StringBuilder(cipher.Length * 2 + 2);
+        sb.Append('<');
+        for (int i = 0; i < cipher.Length; i++) sb.Append(cipher[i].ToString("X2"));
+        sb.Append('>');
+        return sb.ToString();
+    }
 }
 
 /// <summary>Data for an embedded TrueType font (CIDFont Type 2).</summary>

--- a/src/EggPdf.Pdf/PdfEncryption.cs
+++ b/src/EggPdf.Pdf/PdfEncryption.cs
@@ -178,6 +178,31 @@ public class PdfEncryption
         return uValue;
     }
 
+    /// <summary>
+    /// Encrypt a stream's or string's bytes for the object that contains it
+    /// (PDF 32000 Algorithm 1): RC4 with MD5(fileKey + objNum[3 LE] + gen[2 LE])
+    /// truncated to min(keyLen + 5, 16) bytes. RC4 preserves length, so
+    /// /Length values written for the ciphertext match the plaintext.
+    /// </summary>
+    internal static byte[] EncryptForObject(byte[] fileKey, int objNum, int generation, byte[] data)
+    {
+        var input = new byte[fileKey.Length + 5];
+        Array.Copy(fileKey, input, fileKey.Length);
+        input[fileKey.Length] = (byte)(objNum & 0xFF);
+        input[fileKey.Length + 1] = (byte)((objNum >> 8) & 0xFF);
+        input[fileKey.Length + 2] = (byte)((objNum >> 16) & 0xFF);
+        input[fileKey.Length + 3] = (byte)(generation & 0xFF);
+        input[fileKey.Length + 4] = (byte)((generation >> 8) & 0xFF);
+
+        byte[] hash;
+        using (var md5 = MD5.Create())
+            hash = md5.ComputeHash(input);
+
+        var objKey = new byte[Math.Min(fileKey.Length + 5, 16)];
+        Array.Copy(hash, objKey, objKey.Length);
+        return RC4(objKey, data);
+    }
+
     /// <summary>RC4 encryption/decryption.</summary>
     internal static byte[] RC4(byte[] key, byte[] data)
     {

--- a/src/EggPdf.Service/Program.cs
+++ b/src/EggPdf.Service/Program.cs
@@ -282,8 +282,7 @@ app.MapPost("/api/encrypt", async (HttpContext ctx) =>
     if (string.IsNullOrEmpty(request?.Html))
         return Results.BadRequest(new { error = "html field is required" });
 
-    var pdfDoc = new EggPdf.Pdf.PdfDocument();
-    pdfDoc.Encryption = new EggPdf.Pdf.PdfEncryption
+    var encryption = new EggPdf.Pdf.PdfEncryption
     {
         UserPassword = request.UserPassword ?? "",
         OwnerPassword = request.OwnerPassword ?? "owner",
@@ -292,7 +291,7 @@ app.MapPost("/api/encrypt", async (HttpContext ctx) =>
         AllowModifying = request.AllowModifying ?? false,
     };
 
-    var pdf = EggPdf.HtmlToPdf.Render(request.Html);
+    var pdf = EggPdf.HtmlToPdf.Render(request.Html, encryption);
     return Results.File(pdf, "application/pdf", "encrypted.pdf");
 });
 

--- a/src/EggPdf/HtmlToPdf.cs
+++ b/src/EggPdf/HtmlToPdf.cs
@@ -126,7 +126,24 @@ public static class HtmlToPdf
         return RenderInternal(html ?? "", basePath);
     }
 
-    private static byte[] RenderInternal(string html, string? basePath)
+    /// <summary>
+    /// Render HTML to an RC4-encrypted PDF (view-only protection / permission
+    /// flags). All streams and strings are encrypted per the PDF 1.7 Standard
+    /// security handler.
+    /// </summary>
+    public static byte[] Render(string? html, Pdf.PdfEncryption encryption)
+    {
+        return RenderInternal(html ?? "", null, encryption);
+    }
+
+    /// <summary>Render HTML to an RC4-encrypted PDF asynchronously.</summary>
+    public static Task<byte[]> RenderAsync(string? html, Pdf.PdfEncryption encryption, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(RenderInternal(html ?? "", null, encryption));
+    }
+
+    private static byte[] RenderInternal(string html, string? basePath, Pdf.PdfEncryption? encryption = null)
     {
         // 1. Parse HTML -> DOM
         var document = HtmlParser.Parse(html);
@@ -177,7 +194,7 @@ public static class HtmlToPdf
             var layoutRoot = BlockLayout.LayoutDocument(document, contentWidthPx, contentHeightPx, cascadeResolver);
 
             // 6. Resolve images (load data from src attributes)
-            var pdfDoc = new PdfDocument();
+            var pdfDoc = new PdfDocument { Encryption = encryption };
             ResolveImages(layoutRoot, pdfDoc);
 
             // 6b. Subset and embed TrueType fonts for non-standard fonts

--- a/tests/EggPdf.Tests.E2E/ApiEndpointTests.cs
+++ b/tests/EggPdf.Tests.E2E/ApiEndpointTests.cs
@@ -110,6 +110,30 @@ public class ApiEndpointTests
     }
 
     [Fact]
+    public async Task Encrypt_ReturnsEncryptedPdf()
+    {
+        var content = new StringContent(
+            JsonSerializer.Serialize(new
+            {
+                html = "<html><body><p>Confidential body text</p></body></html>",
+                ownerPassword = "owner-secret",
+                allowCopying = false,
+            }),
+            Encoding.UTF8, "application/json");
+
+        var resp = await _client.PostAsync($"{_fixture.BaseUrl}/api/encrypt", content);
+
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        var bytes = await resp.Content.ReadAsByteArrayAsync();
+        Encoding.ASCII.GetString(bytes, 0, 5).Should().Be("%PDF-");
+
+        var raw = Encoding.Latin1.GetString(bytes);
+        raw.Should().Contain("/Encrypt <<", "the response must actually be encrypted");
+        raw.Should().NotContain("Confidential body text",
+            "an encrypted PDF must not leak plaintext content");
+    }
+
+    [Fact]
     public async Task PrintPreview_ReturnsHtml()
     {
         var content = new StringContent(

--- a/tests/EggPdf.Tests.Unit/Pdf/PdfEncryptionE2ETests.cs
+++ b/tests/EggPdf.Tests.Unit/Pdf/PdfEncryptionE2ETests.cs
@@ -1,0 +1,317 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using EggPdf.Pdf;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Pdf;
+
+/// <summary>
+/// End-to-end encryption tests that act as an independent, spec-compliant
+/// PDF reader: they take /O, /P, /ID from the file, derive the file key from
+/// the user password per PDF 32000 Algorithm 2, verify /U per Algorithm 4/5,
+/// derive per-object keys per Algorithm 1, and RC4-decrypt streams/strings.
+/// A derivation bug anywhere in the library makes these fail — the same way
+/// a real viewer would show garbage.
+/// </summary>
+public class PdfEncryptionE2ETests
+{
+    private const string Secret = "Top secret certificate text";
+
+    // ---------- mini spec-compliant reader ----------
+
+    private static readonly byte[] Pad =
+    {
+        0x28, 0xBF, 0x4E, 0x5E, 0x4E, 0x75, 0x8A, 0x41,
+        0x64, 0x00, 0x4B, 0x49, 0x43, 0x28, 0x46, 0x57,
+        0x44, 0x28, 0x55, 0x78, 0x65, 0x63, 0x68, 0x6E,
+        0x69, 0x63, 0x61, 0x6C, 0x20, 0x49, 0x6E, 0x66
+    };
+
+    private static byte[] Md5(params byte[][] parts)
+    {
+        using var md5 = MD5.Create();
+        using var ms = new MemoryStream();
+        foreach (var p in parts) ms.Write(p, 0, p.Length);
+        return md5.ComputeHash(ms.ToArray());
+    }
+
+    private static byte[] Rc4(byte[] key, byte[] data)
+    {
+        var s = new byte[256];
+        for (int i = 0; i < 256; i++) s[i] = (byte)i;
+        int j = 0;
+        for (int i = 0; i < 256; i++)
+        {
+            j = (j + s[i] + key[i % key.Length]) & 0xFF;
+            (s[i], s[j]) = (s[j], s[i]);
+        }
+        var result = new byte[data.Length];
+        int x = 0, y = 0;
+        for (int i = 0; i < data.Length; i++)
+        {
+            x = (x + 1) & 0xFF;
+            y = (y + s[x]) & 0xFF;
+            (s[x], s[y]) = (s[y], s[x]);
+            result[i] = (byte)(data[i] ^ s[(s[x] + s[y]) & 0xFF]);
+        }
+        return result;
+    }
+
+    private static byte[] PadPassword(string password)
+    {
+        var pwd = Encoding.GetEncoding(28591).GetBytes(password);
+        var padded = new byte[32];
+        int len = Math.Min(pwd.Length, 32);
+        Array.Copy(pwd, padded, len);
+        Array.Copy(Pad, 0, padded, len, 32 - len);
+        return padded;
+    }
+
+    /// <summary>PDF 32000 Algorithm 2: file encryption key from the user password.</summary>
+    private static byte[] DeriveFileKey(string userPassword, byte[] oValue, int permissions, byte[] docId, int keyLenBytes)
+    {
+        var pBytes = new byte[]
+        {
+            (byte)(permissions & 0xFF), (byte)((permissions >> 8) & 0xFF),
+            (byte)((permissions >> 16) & 0xFF), (byte)((permissions >> 24) & 0xFF),
+        };
+        var hash = Md5(PadPassword(userPassword), oValue, pBytes, docId);
+        if (keyLenBytes > 5)
+            for (int i = 0; i < 50; i++)
+            {
+                var trunc = new byte[keyLenBytes];
+                Array.Copy(hash, trunc, keyLenBytes);
+                hash = Md5(trunc);
+            }
+        var key = new byte[keyLenBytes];
+        Array.Copy(hash, key, keyLenBytes);
+        return key;
+    }
+
+    /// <summary>PDF 32000 Algorithm 1: per-object key.</summary>
+    private static byte[] ObjectKey(byte[] fileKey, int objNum)
+    {
+        var input = new byte[fileKey.Length + 5];
+        Array.Copy(fileKey, input, fileKey.Length);
+        input[fileKey.Length] = (byte)(objNum & 0xFF);
+        input[fileKey.Length + 1] = (byte)((objNum >> 8) & 0xFF);
+        input[fileKey.Length + 2] = (byte)((objNum >> 16) & 0xFF);
+        // generation 0 -> two zero bytes already in place
+        var hash = Md5(input);
+        var key = new byte[Math.Min(fileKey.Length + 5, 16)];
+        Array.Copy(hash, key, key.Length);
+        return key;
+    }
+
+    private static string Latin1(byte[] pdf) => Encoding.Latin1.GetString(pdf);
+
+    private static byte[] HexToBytes(string hex)
+    {
+        var result = new byte[hex.Length / 2];
+        for (int i = 0; i < result.Length; i++)
+            result[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+        return result;
+    }
+
+    private static (byte[] o, byte[] u, int p, byte[] id, int lengthBits) ReadEncryptDict(string text)
+    {
+        var o = HexToBytes(Regex.Match(text, @"/O <([0-9A-Fa-f]+)>").Groups[1].Value);
+        var u = HexToBytes(Regex.Match(text, @"/U <([0-9A-Fa-f]+)>").Groups[1].Value);
+        int p = int.Parse(Regex.Match(text, @"/P (-?\d+)").Groups[1].Value);
+        var id = HexToBytes(Regex.Match(text, @"/ID \[<([0-9A-Fa-f]+)>").Groups[1].Value);
+        int lengthBits = int.Parse(Regex.Match(text, @"/Encrypt << [^>]*?/Length (\d+)").Groups[1].Value);
+        return (o, u, p, id, lengthBits);
+    }
+
+    /// <summary>Extract a stream's bytes and its owning object number.</summary>
+    private static (byte[] data, int objNum) ExtractStream(byte[] pdf, string text, int searchFrom)
+    {
+        int streamIdx = text.IndexOf("stream\n", searchFrom, StringComparison.Ordinal);
+        streamIdx.Should().BeGreaterThan(0);
+        int dataStart = streamIdx + "stream\n".Length;
+        int lenIdx = text.LastIndexOf("/Length ", streamIdx, StringComparison.Ordinal);
+        int numEnd = lenIdx + "/Length ".Length;
+        int numStart = numEnd;
+        while (numEnd < text.Length && char.IsDigit(text[numEnd])) numEnd++;
+        int length = int.Parse(text.Substring(numStart, numEnd - numStart));
+
+        int objIdx = text.LastIndexOf(" 0 obj", streamIdx, StringComparison.Ordinal);
+        int objNumStart = objIdx;
+        while (objNumStart > 0 && char.IsDigit(text[objNumStart - 1])) objNumStart--;
+        int objNum = int.Parse(text.Substring(objNumStart, objIdx - objNumStart));
+
+        var data = new byte[length];
+        Array.Copy(pdf, dataStart, data, 0, length);
+        return (data, objNum);
+    }
+
+    private static byte[] InflateZlib(byte[] data)
+    {
+        using var input = new MemoryStream(data, 2, data.Length - 2);
+        using var deflate = new DeflateStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        deflate.CopyTo(output);
+        return output.ToArray();
+    }
+
+    private static byte[] RenderEncrypted(PdfEncryption encryption, bool compress = false, string? title = null)
+    {
+        var doc = new PdfDocument { Encryption = encryption, CompressContentStreams = compress, Title = title };
+        var page = doc.AddPage(595, 842);
+        page.AddText(Secret, 50, 700, "Helvetica", 12);
+        page.AddLink(50, 690, 100, 14, "https://example.com/private-link");
+        return doc.ToByteArray();
+    }
+
+    // ---------- tests ----------
+
+    [Fact]
+    public void Encrypted_ContentStreamAndStrings_AreNotPlaintext()
+    {
+        var pdf = RenderEncrypted(new PdfEncryption { OwnerPassword = "owner" }, title: "Hidden Title");
+        var text = Latin1(pdf);
+
+        text.Should().NotContain(Secret, "content stream bytes must be RC4-encrypted");
+        text.Should().NotContain("Tj", "text-showing operators must not be readable in an encrypted PDF");
+        text.Should().NotContain("private-link", "annotation URI strings must be encrypted");
+        text.Should().NotContain("Hidden Title", "Info dictionary strings must be encrypted");
+        text.Should().Contain("/Encrypt <<");
+        text.Should().Contain("/ID [<");
+    }
+
+    [Fact]
+    public void Encrypted_SpecReader_VerifiesUserPasswordViaUValue()
+    {
+        var pdf = RenderEncrypted(new PdfEncryption { OwnerPassword = "owner", UserPassword = "user1" });
+        var (o, u, p, id, lengthBits) = ReadEncryptDict(Latin1(pdf));
+
+        var fileKey = DeriveFileKey("user1", o, p, id, lengthBits / 8);
+
+        // Algorithm 5 (R3): U = RC4^20(key XOR rounds, MD5(padding + docId)), first 16 bytes
+        var expected = Rc4(fileKey, Md5(Pad, id));
+        for (int round = 1; round <= 19; round++)
+        {
+            var roundKey = new byte[fileKey.Length];
+            for (int i = 0; i < fileKey.Length; i++) roundKey[i] = (byte)(fileKey[i] ^ round);
+            expected = Rc4(roundKey, expected);
+        }
+
+        for (int i = 0; i < 16; i++)
+            u[i].Should().Be(expected[i], "a spec-compliant reader must be able to verify the user password");
+    }
+
+    [Fact]
+    public void Encrypted_SpecReader_DecryptsContentStream()
+    {
+        var pdf = RenderEncrypted(new PdfEncryption { OwnerPassword = "owner" });
+        var text = Latin1(pdf);
+        var (o, _, p, id, lengthBits) = ReadEncryptDict(text);
+        var fileKey = DeriveFileKey("", o, p, id, lengthBits / 8); // empty user password
+
+        var (cipher, objNum) = ExtractStream(pdf, text, 0);
+        var plain = Encoding.Latin1.GetString(Rc4(ObjectKey(fileKey, objNum), cipher));
+
+        plain.Should().Contain("(" + Secret + ") Tj",
+            "decrypting with the spec-derived per-object key must recover the operators");
+    }
+
+    [Fact]
+    public void Encrypted_WithCompression_DecryptsThenInflates()
+    {
+        var pdf = RenderEncrypted(new PdfEncryption { OwnerPassword = "owner" }, compress: true);
+        var text = Latin1(pdf);
+        var (o, _, p, id, lengthBits) = ReadEncryptDict(text);
+        var fileKey = DeriveFileKey("", o, p, id, lengthBits / 8);
+
+        var (cipher, objNum) = ExtractStream(pdf, text, 0);
+        var inflated = InflateZlib(Rc4(ObjectKey(fileKey, objNum), cipher));
+
+        Encoding.Latin1.GetString(inflated).Should().Contain("(" + Secret + ") Tj",
+            "compression must be applied before encryption (decrypt, then inflate)");
+    }
+
+    [Fact]
+    public void Encrypted_SpecReader_DecryptsUriString()
+    {
+        var pdf = RenderEncrypted(new PdfEncryption { OwnerPassword = "owner" });
+        var text = Latin1(pdf);
+        var (o, _, p, id, lengthBits) = ReadEncryptDict(text);
+        var fileKey = DeriveFileKey("", o, p, id, lengthBits / 8);
+
+        // The URI hex string lives in the page dictionary object
+        // "/Type /Page /Parent" pins the page dict ("/Type /Pages" is the page tree)
+        var uriMatch = Regex.Match(text, @"(\d+) 0 obj\s*<< /Type /Page /Parent[\s\S]*?/URI <([0-9A-Fa-f]+)>");
+        uriMatch.Success.Should().BeTrue("the URI must be written as an encrypted hex string");
+
+        int pageObjNum = int.Parse(uriMatch.Groups[1].Value);
+        var plain = Encoding.Latin1.GetString(
+            Rc4(ObjectKey(fileKey, pageObjNum), HexToBytes(uriMatch.Groups[2].Value)));
+        plain.Should().Be("https://example.com/private-link");
+    }
+
+    [Fact]
+    public void Encrypted_40Bit_RoundtripsToo()
+    {
+        var pdf = RenderEncrypted(new PdfEncryption { OwnerPassword = "owner", KeyLength = 40 });
+        var text = Latin1(pdf);
+        var (o, _, p, id, lengthBits) = ReadEncryptDict(text);
+        lengthBits.Should().Be(40);
+        var fileKey = DeriveFileKey("", o, p, id, lengthBits / 8);
+
+        var (cipher, objNum) = ExtractStream(pdf, text, 0);
+        Encoding.Latin1.GetString(Rc4(ObjectKey(fileKey, objNum), cipher))
+            .Should().Contain("(" + Secret + ") Tj");
+    }
+
+    [Fact]
+    public void Permissions_MapToPValueBits()
+    {
+        var pdf = RenderEncrypted(new PdfEncryption
+        {
+            OwnerPassword = "owner",
+            AllowPrinting = false,
+            AllowCopying = false,
+            AllowModifying = false,
+        });
+        var (_, _, p, _, _) = ReadEncryptDict(Latin1(pdf));
+
+        (p & 0x04).Should().Be(0, "printing must be disallowed (bit 3)");
+        (p & 0x08).Should().Be(0, "modifying must be disallowed (bit 4)");
+        (p & 0x10).Should().Be(0, "copying must be disallowed (bit 5)");
+    }
+
+    [Fact]
+    public void HtmlToPdf_RenderWithEncryption_ProducesDecryptablePdf()
+    {
+        var pdf = HtmlToPdf.Render(
+            "<html><body><p>Encrypted pipeline text</p></body></html>",
+            new PdfEncryption { OwnerPassword = "owner", AllowCopying = false });
+        var text = Latin1(pdf);
+
+        text.Should().Contain("/Encrypt <<");
+        text.Should().NotContain("Encrypted pipeline text");
+
+        var (o, _, p, id, lengthBits) = ReadEncryptDict(text);
+        var fileKey = DeriveFileKey("", o, p, id, lengthBits / 8);
+        var (cipher, objNum) = ExtractStream(pdf, text, 0);
+        Encoding.Latin1.GetString(Rc4(ObjectKey(fileKey, objNum), cipher))
+            .Should().Contain("Encrypted pipeline text");
+    }
+
+    [Fact]
+    public void NoEncryption_OutputUnchanged()
+    {
+        var doc = new PdfDocument();
+        var page = doc.AddPage(595, 842);
+        page.AddText(Secret, 50, 700, "Helvetica", 12);
+        var text = Latin1(doc.ToByteArray());
+
+        text.Should().Contain("(" + Secret + ") Tj");
+        text.Should().NotContain("/Encrypt");
+    }
+}


### PR DESCRIPTION
## Summary
PDF encryption was cosmetic: the trailer declared `/Encrypt` with computed O/U/P values, but **no stream or string was ever encrypted** — compliant viewers decrypting per spec would render garbage, `/api/encrypt` returned a plain PDF (it configured a `PdfDocument` it never used), and `HtmlToPdf` had no encryption pathway.

This PR makes the Standard security handler (V2/R3, RC4 40/128-bit) real:

- File key computed **before** object writing; every stream (content, FontFile2, ToUnicode, images, SMasks) and every string (Info entries incl. CreationDate, link URIs, outline titles, CIDSystemInfo Registry/Ordering) is encrypted with the per-object key (PDF 32000 Algorithm 1). Compression is applied **before** encryption. Encrypted strings are written as hex strings.
- New public one-call API: `HtmlToPdf.Render(html, PdfEncryption)` + `RenderAsync` overload; `/api/encrypt` now actually uses it.
- Unencrypted output is byte-for-byte unchanged (no-op path).
- Docs (llms.txt, site/llms.txt) updated with the real API.

## Test evidence
- Unit: **988/988** (9 new). The new tests act as an **independent spec-compliant reader**: they read `/O /P /ID` from the file, derive the file key from the user password (Algorithm 2), verify `/U` (Algorithm 5), derive per-object keys (Algorithm 1) with their own MD5/RC4 implementation, and decrypt streams and strings back to the expected plaintext — covering 128-bit, 40-bit, compressed+encrypted, URI strings, permission bits, and the unencrypted no-op path.
- Layout: **554/554**
- E2E (API): **12/12** including a new `/api/encrypt` test asserting the response declares `/Encrypt` and leaks no plaintext.

Not a hot path: encryption is off by default; the unencrypted path gains only a null check per stream (no benchmark impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)