### PR TITLE
perf: whole-project hot-path pass — cascade prefilter, pseudo-rule index, caches

### DIFF
--- a/src/EggPdf.Css/BasicStyleResolver.cs
+++ b/src/EggPdf.Css/BasicStyleResolver.cs
@@ -210,16 +210,19 @@ public class BasicStyleResolver
     /// </summary>
     private static void ResolveCustomProperties(ComputedStyle style)
     {
-        var toResolve = new List<KeyValuePair<string, string>>();
+        // Lazy list + '(' gate: the common case has no var()/env() at all.
+        List<KeyValuePair<string, string>>? toResolve = null;
         foreach (var kv in style.All)
         {
+            if (kv.Value.IndexOf('(') < 0) continue;
             if (!CssVariableResolver.IsCustomProperty(kv.Key) &&
                 (kv.Value.IndexOf("var(", StringComparison.OrdinalIgnoreCase) >= 0 ||
                  kv.Value.IndexOf("env(", StringComparison.OrdinalIgnoreCase) >= 0))
             {
-                toResolve.Add(kv);
+                (toResolve ??= new List<KeyValuePair<string, string>>()).Add(kv);
             }
         }
+        if (toResolve == null) return;
 
         foreach (var kv in toResolve)
         {

--- a/src/EggPdf.Css/Cascade/CascadeResolver.cs
+++ b/src/EggPdf.Css/Cascade/CascadeResolver.cs
@@ -15,7 +15,40 @@ public class CascadeResolver
 {
     private readonly List<CssStyleRule> _authorRules = new();
     private readonly List<int> _authorRuleSpecificities = new();
+    private readonly List<RuleFilter> _authorRuleFilters = new();
     private readonly BasicStyleResolver _uaResolver = new();
+
+    /// <summary>
+    /// Pseudo-element rules indexed by pseudo name (before/after/marker/...),
+    /// with base selector and specificity precomputed — ResolvePseudoElement
+    /// runs ~6x per element and must not rescan every author rule.
+    /// </summary>
+    private readonly Dictionary<string, List<(string baseSelector, CssStyleRule rule, int specScore, int order)>>
+        _pseudoRules = new(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly string[] PseudoElementNames =
+        { "before", "after", "marker", "first-line", "first-letter", "placeholder" };
+
+    // Reused per-element scratch: Resolve is called once per element on a
+    // single-threaded, per-render resolver; allocating these per call was
+    // measurable churn.
+    private readonly List<(CssDeclaration decl, int specificity, int layerOrder, int order)> _matchScratch = new();
+    private readonly Dictionary<string, (string value, bool important, int specificity, int layerOrder, int order)>
+        _winnersScratch = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Cheap per-rule rejection data derived from the rightmost compound.
+    /// Extra simple selectors (attributes, pseudo-classes) only narrow a
+    /// match, so a required tag/id/class extracted before them stays sound.
+    /// </summary>
+    private struct RuleFilter
+    {
+        public string? Tag;
+        public string? Id;
+        public string? Class;
+        public bool AlwaysCheck; // no cheap rejection possible
+        public bool SkipAlways;  // '::' pseudo-element rule — Matches() is always false
+    }
     private readonly string _mediaType;
     private readonly float _pageWidth;
     /// <summary>@property initial-values keyed by custom property name.</summary>
@@ -74,10 +107,20 @@ public class CascadeResolver
         // 2. Collect matching author rules with specificity and layer order
         // Tuple: (decl, specificity, layerOrder, sourceOrder)
         // layerOrder: int.MaxValue = unlayered (wins), 0,1,2... = layer index (later wins)
-        var matches = new List<(CssDeclaration decl, int specificity, int layerOrder, int order)>();
+        var matches = _matchScratch;
+        matches.Clear();
+
+        // Per-element values the rule prefilter tests against
+        string elemTag = element.TagName;
+        string? elemId = element.GetAttribute("id");
+        string? elemClass = element.GetAttribute("class");
 
         for (int ri = 0; ri < _authorRules.Count; ri++)
         {
+            var filter = _authorRuleFilters[ri];
+            if (filter.SkipAlways) continue;
+            if (!FilterMightMatch(in filter, elemTag, elemId, elemClass)) continue;
+
             var rule = _authorRules[ri];
             if (SelectorMatcher.Matches(rule.SelectorText, element))
             {
@@ -104,7 +147,8 @@ public class CascadeResolver
 
         // 4. Apply in order (later wins for same property at same importance level)
         // Group by property, last one wins (unless !important overrides)
-        var propertyWinners = new Dictionary<string, (string value, bool important, int specificity, int layerOrder, int order)>(StringComparer.OrdinalIgnoreCase);
+        var propertyWinners = _winnersScratch;
+        propertyWinners.Clear();
 
         foreach (var (decl, spec, layerOrder, order) in matches)
         {
@@ -196,38 +240,19 @@ public class CascadeResolver
     /// <summary>Resolve computed style for a pseudo-element (::before or ::after).</summary>
     public ComputedStyle? ResolvePseudoElement(HtmlElement element, string pseudo, ComputedStyle? parentStyle)
     {
-        // Collect matching rules that target this pseudo-element
-        string pseudoSuffix = "::" + pseudo;
-        string pseudoSuffixSingle = ":" + pseudo; // legacy single-colon
+        // Indexed at AddRules time — no rules for this pseudo means no scan at all
+        // (this method runs ~6x per element).
+        if (!_pseudoRules.TryGetValue(pseudo, out var candidates))
+            return null;
+
         var matches = new List<(CssDeclaration decl, int specificity, int order)>();
-        int ruleOrder = 0;
-
-        foreach (var rule in _authorRules)
+        foreach (var (baseSelector, rule, specScore, order) in candidates)
         {
-            var sel = rule.SelectorText;
-            bool hasPseudo = false;
-            string? baseSelector = null;
-
-            if (sel.EndsWith(pseudoSuffix, StringComparison.OrdinalIgnoreCase))
+            if (SelectorMatcher.Matches(baseSelector, element))
             {
-                baseSelector = sel.Substring(0, sel.Length - pseudoSuffix.Length);
-                hasPseudo = true;
-            }
-            else if (sel.EndsWith(pseudoSuffixSingle, StringComparison.OrdinalIgnoreCase))
-            {
-                baseSelector = sel.Substring(0, sel.Length - pseudoSuffixSingle.Length);
-                hasPseudo = true;
-            }
-
-            if (hasPseudo && !string.IsNullOrEmpty(baseSelector) && SelectorMatcher.Matches(baseSelector, element))
-            {
-                var spec = SelectorMatcher.CalculateSpecificity(baseSelector);
-                int specScore = spec.A * 10000 + spec.B * 100 + spec.C + 1; // +1 for pseudo-element
-
                 foreach (var decl in rule.Declarations)
-                    matches.Add((decl, specScore, ruleOrder));
+                    matches.Add((decl, specScore, order));
             }
-            ruleOrder++;
         }
 
         if (matches.Count == 0) return null;
@@ -326,17 +351,20 @@ public class CascadeResolver
     /// </summary>
     private static void ResolveCustomProperties(ComputedStyle style)
     {
-        // Collect properties that need resolution (avoid modifying during iteration)
-        var toResolve = new List<KeyValuePair<string, string>>();
+        // Collect properties that need resolution (avoid modifying during iteration).
+        // Lazy list + '(' gate: the common case has no var()/env() at all.
+        List<KeyValuePair<string, string>>? toResolve = null;
         foreach (var kv in style.All)
         {
+            if (kv.Value.IndexOf('(') < 0) continue;
             if (!CssVariableResolver.IsCustomProperty(kv.Key) &&
                 (kv.Value.IndexOf("var(", StringComparison.OrdinalIgnoreCase) >= 0 ||
                  kv.Value.IndexOf("env(", StringComparison.OrdinalIgnoreCase) >= 0))
             {
-                toResolve.Add(kv);
+                (toResolve ??= new List<KeyValuePair<string, string>>()).Add(kv);
             }
         }
+        if (toResolve == null) return;
 
         foreach (var kv in toResolve)
         {
@@ -380,8 +408,119 @@ public class CascadeResolver
         {
             var spec = SelectorMatcher.CalculateSpecificity(rule.SelectorText);
             _authorRuleSpecificities.Add(spec.A * 10000 + spec.B * 100 + spec.C);
+            int order = _authorRules.Count;
             _authorRules.Add(rule);
+            _authorRuleFilters.Add(BuildFilter(rule.SelectorText));
+            IndexPseudoElementRule(rule, order);
         }
+    }
+
+    /// <summary>If the selector targets a pseudo-element, index it by pseudo name.</summary>
+    private void IndexPseudoElementRule(CssStyleRule rule, int order)
+    {
+        var sel = rule.SelectorText;
+        foreach (var name in PseudoElementNames)
+        {
+            string? baseSelector = null;
+            var doubleColon = "::" + name;
+            var singleColon = ":" + name;
+            if (sel.EndsWith(doubleColon, StringComparison.OrdinalIgnoreCase))
+                baseSelector = sel.Substring(0, sel.Length - doubleColon.Length);
+            else if (sel.EndsWith(singleColon, StringComparison.OrdinalIgnoreCase))
+                baseSelector = sel.Substring(0, sel.Length - singleColon.Length);
+
+            if (string.IsNullOrEmpty(baseSelector)) continue;
+
+            var spec = SelectorMatcher.CalculateSpecificity(baseSelector!);
+            int specScore = spec.A * 10000 + spec.B * 100 + spec.C + 1; // +1 for pseudo-element
+
+            if (!_pseudoRules.TryGetValue(name, out var list))
+                _pseudoRules[name] = list = new List<(string, CssStyleRule, int, int)>();
+            list.Add((baseSelector!, rule, specScore, order));
+            return; // a selector ends in at most one pseudo-element
+        }
+    }
+
+    /// <summary>Extract cheap rejection requirements from the rightmost compound.</summary>
+    private static RuleFilter BuildFilter(string selectorText)
+    {
+        var f = new RuleFilter();
+        var sel = selectorText.Trim();
+
+        // Selector lists and escaped identifiers: just run the full matcher.
+        if (sel.Length == 0 || sel.IndexOf(',') >= 0 || sel.IndexOf('\\') >= 0)
+        {
+            f.AlwaysCheck = true;
+            return f;
+        }
+
+        // '::' pseudo-element selectors never match an element directly
+        // (SelectorMatcher.Matches rejects them) — skip without matching.
+        if (sel.IndexOf("::", StringComparison.Ordinal) >= 0)
+        {
+            f.SkipAlways = true;
+            return f;
+        }
+
+        // Find the rightmost compound: scan backwards for a top-level combinator
+        // (spaces/'+' inside [...] or (...) don't count).
+        int depth = 0, start = 0;
+        for (int i = sel.Length - 1; i >= 0; i--)
+        {
+            char c = sel[i];
+            if (c == ')' || c == ']') depth++;
+            else if (c == '(' || c == '[') depth--;
+            else if (depth == 0 && (c == ' ' || c == '>' || c == '+' || c == '~'))
+            {
+                start = i + 1;
+                break;
+            }
+        }
+
+        // Parse the compound's leading tag and '.class'/'#id' tokens; stop at
+        // '[' / ':' / anything else — later constraints only narrow the match.
+        int p = start;
+        if (p < sel.Length && sel[p] == '*')
+        {
+            p++;
+        }
+        else
+        {
+            int identStart = p;
+            while (p < sel.Length && (char.IsLetterOrDigit(sel[p]) || sel[p] == '-' || sel[p] == '_')) p++;
+            if (p > identStart) f.Tag = sel.Substring(identStart, p - identStart);
+        }
+
+        while (p < sel.Length && (sel[p] == '.' || sel[p] == '#'))
+        {
+            char kind = sel[p];
+            p++;
+            int identStart = p;
+            while (p < sel.Length && (char.IsLetterOrDigit(sel[p]) || sel[p] == '-' || sel[p] == '_')) p++;
+            if (p == identStart) { f.AlwaysCheck = true; return f; }
+            var ident = sel.Substring(identStart, p - identStart);
+            if (kind == '#') f.Id = ident;
+            else if (f.Class == null) f.Class = ident;
+        }
+
+        if (f.Tag == null && f.Id == null && f.Class == null)
+            f.AlwaysCheck = true;
+        return f;
+    }
+
+    private static bool FilterMightMatch(in RuleFilter f, string tagName, string? id, string? classAttr)
+    {
+        if (f.AlwaysCheck) return true;
+        if (f.Tag != null && !string.Equals(f.Tag, tagName, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (f.Id != null && !string.Equals(f.Id, id, StringComparison.OrdinalIgnoreCase))
+            return false;
+        // Substring check may false-positive ("foo" in "foobar") — that only
+        // means the full matcher runs; it can never false-negative.
+        if (f.Class != null && (classAttr == null ||
+            classAttr.IndexOf(f.Class, StringComparison.OrdinalIgnoreCase) < 0))
+            return false;
+        return true;
     }
 
     /// <summary>Remove spaces around colons in container conditions: "min-width : 400px" → "min-width:400px".</summary>
@@ -484,9 +623,16 @@ public class CascadeResolver
         {
             var val = kv.Value;
             if (val == null) continue;
-            var lower = val.Trim().ToLowerInvariant();
-            if (lower != "inherit" && lower != "initial" && lower != "unset" && lower != "revert")
-                continue;
+            // Cheap gate: the four CSS-wide keywords are 5-7 chars; skip the
+            // Trim/ToLower allocations for everything that can't be one.
+            if (val.Length < 5 || val.Length > 16) continue;
+            var trimmed = val.Trim();
+            string lower;
+            if (trimmed.Equals("inherit", StringComparison.OrdinalIgnoreCase)) lower = "inherit";
+            else if (trimmed.Equals("initial", StringComparison.OrdinalIgnoreCase)) lower = "initial";
+            else if (trimmed.Equals("unset", StringComparison.OrdinalIgnoreCase)) lower = "unset";
+            else if (trimmed.Equals("revert", StringComparison.OrdinalIgnoreCase)) lower = "revert";
+            else continue;
 
             string? resolved = null;
             bool remove = false;

--- a/src/EggPdf.Html/HtmlTreeBuilder.cs
+++ b/src/EggPdf.Html/HtmlTreeBuilder.cs
@@ -186,6 +186,23 @@ internal class HtmlTreeBuilder
         if (tagName == "html" || tagName == "body" || tagName == "head")
             return;
 
+        // Fast path: properly nested close — no scratch stack needed.
+        if (_openElements.Count > 0)
+        {
+            var topElement = _openElements.Peek();
+            if (topElement.TagName == tagName)
+            {
+                _openElements.Pop();
+                return;
+            }
+            if (topElement.TagName == "body" || topElement.TagName == "html")
+                return;
+        }
+        else
+        {
+            return;
+        }
+
         // Pop elements until we find matching start tag
         var temp = new Stack<HtmlElement>();
         bool found = false;

--- a/src/EggPdf.Layout/BlockLayout.cs
+++ b/src/EggPdf.Layout/BlockLayout.cs
@@ -79,6 +79,9 @@ public static class BlockLayout
     {
         _viewportWidth = pageWidth;
         _viewportHeight = pageHeight;
+        // Per-render cache: without clearing, a pooled thread retains every
+        // table element from every past render (unbounded growth).
+        _tableColumnWidthCache?.Clear();
 
         var root = new LayoutBox
         {
@@ -424,6 +427,11 @@ public static class BlockLayout
         // ("Căn cứ <strong>Luật</strong>": the space precedes the inline element).
         bool prevTextEndedWithSpace = false;
 
+        // Table-row column geometry, computed once per row on first cell —
+        // the previous per-cell rescans were O(cells²) per row.
+        Dictionary<HtmlElement, int>? rowCellColOffsets = null;
+        int rowTotalColumns = 0;
+
         foreach (var childNode in element.ChildNodes)
         {
             if (childNode is HtmlElement childElem)
@@ -458,8 +466,24 @@ public static class BlockLayout
                     // Table row layout: cells go side-by-side (horizontal)
                     if (IsTableRow(style.Display) && IsTableCell(childStyle.Display))
                     {
-                        int totalColumns = CountTableColumns(element);
-                        int colOffset = CountPreviousColumns(element, childElem);
+                        if (rowCellColOffsets == null)
+                        {
+                            rowCellColOffsets = new Dictionary<HtmlElement, int>();
+                            int running = 0;
+                            foreach (var rowChild in element.ChildNodes)
+                            {
+                                if (rowChild is HtmlElement rc)
+                                {
+                                    rowCellColOffsets[rc] = running;
+                                    if (rc.TagName == "td" || rc.TagName == "th")
+                                        running += GetColspan(rc);
+                                }
+                            }
+                            rowTotalColumns = running;
+                        }
+                        int totalColumns = rowTotalColumns;
+                        int colOffset = rowCellColOffsets.TryGetValue(childElem, out var cachedOffset)
+                            ? cachedOffset : 0;
                         int colspan = GetColspan(childElem);
 
                         // border-collapse inherits from <table> via CSS inheritance
@@ -1983,28 +2007,6 @@ public static class BlockLayout
     }
 
     /// <summary>Count total column slots in a row (respecting colspan).</summary>
-    private static int CountTableColumns(HtmlElement row)
-    {
-        int count = 0;
-        foreach (var child in row.ChildNodes)
-            if (child is HtmlElement e && (e.TagName == "td" || e.TagName == "th"))
-                count += GetColspan(e);
-        return count;
-    }
-
-    /// <summary>Count column slots before the current cell (respecting colspan).</summary>
-    private static int CountPreviousColumns(HtmlElement row, HtmlElement currentCell)
-    {
-        int columns = 0;
-        foreach (var child in row.ChildNodes)
-        {
-            if (child == currentCell) return columns;
-            if (child is HtmlElement e && (e.TagName == "td" || e.TagName == "th"))
-                columns += GetColspan(e);
-        }
-        return columns;
-    }
-
     /// <summary>Get colspan attribute value (default 1).</summary>
     private static int GetColspan(HtmlElement cell)
     {

--- a/src/EggPdf.Layout/StandardFontMetrics.cs
+++ b/src/EggPdf.Layout/StandardFontMetrics.cs
@@ -157,10 +157,30 @@ public static class StandardFontMetrics
         return ResolveBaseFontName(fontFamily, bold, italic);
     }
 
+    /// <summary>
+    /// Memoized: this runs for every word measured (the hottest call in
+    /// layout), and the lowercasing + substring scans are pure functions of
+    /// the inputs. Distinct (family, bold, italic) triples per process are
+    /// bounded by the documents' font lists.
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(string family, bool bold, bool italic), string>
+        _baseNameCache = new System.Collections.Concurrent.ConcurrentDictionary<(string, bool, bool), string>();
+    private const int BaseNameCacheMaxEntries = 512;
+
     private static string ResolveBaseFontName(string? fontFamily, bool bold, bool italic)
     {
+        var key = (fontFamily ?? "", bold, italic);
+        if (_baseNameCache.TryGetValue(key, out var cached)) return cached;
 
-        var family = (fontFamily ?? "").ToLowerInvariant().Trim();
+        var result = ResolveBaseFontNameUncached(key.Item1, bold, italic);
+        if (_baseNameCache.Count < BaseNameCacheMaxEntries)
+            _baseNameCache.TryAdd(key, result);
+        return result;
+    }
+
+    private static string ResolveBaseFontNameUncached(string fontFamily, bool bold, bool italic)
+    {
+        var family = fontFamily.ToLowerInvariant().Trim();
 
         if (family.IndexOf("monospace", StringComparison.OrdinalIgnoreCase) >= 0 ||
             family.IndexOf("courier", StringComparison.OrdinalIgnoreCase) >= 0 ||

--- a/src/EggPdf.Pdf/PdfPage.cs
+++ b/src/EggPdf.Pdf/PdfPage.cs
@@ -16,6 +16,7 @@ public class PdfPage
     internal HashSet<string> UsedFonts { get; } = new();
     internal List<PdfLinkAnnotation> Links { get; } = new();
     internal List<string> UsedImages { get; } = new();
+    private readonly HashSet<string> _usedImageSet = new();
     internal HashSet<string> UsedExtGStates { get; } = new();
 
     internal PdfPage(float widthPt, float heightPt)
@@ -35,7 +36,9 @@ public class PdfPage
         ContentStream.Append($"{F(letterSpacing)} Tc ");
         ContentStream.Append($"{F(wordSpacing)} Tw ");
         ContentStream.Append($"{F(x)} {F(y)} Td ");
-        ContentStream.Append($"({EscapePdfString(text)}) Tj ");
+        ContentStream.Append('(');
+        AppendEscapedPdfString(ContentStream, text);
+        ContentStream.Append(") Tj ");
         ContentStream.AppendLine("ET");
     }
 
@@ -389,7 +392,7 @@ public class PdfPage
     /// <summary>Add an image at a position with specified dimensions (PDF coordinates).</summary>
     public void AddImage(string imageName, float x, float y, float width, float height)
     {
-        if (!UsedImages.Contains(imageName))
+        if (_usedImageSet.Add(imageName)) // O(1) de-dup; list keeps insertion order
             UsedImages.Add(imageName);
 
         // Save graphics state, apply transformation matrix, draw image, restore
@@ -502,6 +505,29 @@ public class PdfPage
     private static string EscapePdfString(string text)
     {
         var sb = new StringBuilder(text.Length);
+        AppendEscapedPdfString(sb, text);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Escape a PDF literal string directly into a builder — the hot text
+    /// path appends into the content stream without a temporary
+    /// StringBuilder + string per run. Plain-ASCII runs append in one call.
+    /// </summary>
+    private static void AppendEscapedPdfString(StringBuilder sb, string text)
+    {
+        bool simple = true;
+        for (int i = 0; i < text.Length; i++)
+        {
+            char sc = text[i];
+            if (sc >= 128 || sc == '\\' || sc == '(' || sc == ')') { simple = false; break; }
+        }
+        if (simple)
+        {
+            sb.Append(text);
+            return;
+        }
+
         foreach (char c in text)
         {
             if (c == '\\') sb.Append("\\\\");
@@ -521,7 +547,6 @@ public class PdfPage
                     sb.Append('?'); // unmappable
             }
         }
-        return sb.ToString();
     }
 
     /// <summary>Map common Unicode characters to WinAnsiEncoding byte values.</summary>

--- a/src/EggPdf/HtmlToPdf.cs
+++ b/src/EggPdf/HtmlToPdf.cs
@@ -557,51 +557,81 @@ public static class HtmlToPdf
     }
 
     /// <summary>Walk the layout tree and resolve image sources to byte data.</summary>
+    /// <summary>
+    /// Process-wide decoded-image cache for data: URIs only — their content
+    /// is immutable by construction, so no invalidation is needed. File-path
+    /// sources stay uncached (the file can change on disk between renders).
+    /// PdfImage entries are read-only to all consumers.
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, (byte[] raw, PdfImage? image)>
+        DataUriImageCache = new System.Collections.Concurrent.ConcurrentDictionary<string, (byte[], PdfImage?)>(StringComparer.Ordinal);
+    private const int DataUriImageCacheMaxEntries = 32;
+
+    /// <summary>Test observability: incremented on every image-cache hit.</summary>
+    internal static int ImageCacheHits;
+
     private static void ResolveImages(LayoutBox box, PdfDocument pdfDoc)
     {
         if (!string.IsNullOrEmpty(box.ImageSource))
         {
-            var data = LoadImageData(box.ImageSource);
-            if (data != null)
+            bool cacheable = box.ImageSource.StartsWith("data:", StringComparison.OrdinalIgnoreCase);
+
+            if (cacheable && DataUriImageCache.TryGetValue(box.ImageSource, out var cached))
             {
-                box.ImageData = data;
-                string imgName = "Img" + box.ImageSource.GetHashCode().ToString("X8");
-                PdfImage? pdfImage = null;
+                System.Threading.Interlocked.Increment(ref ImageCacheHits);
+                box.ImageData = cached.raw;
+                if (cached.image != null)
+                    pdfDoc.AddImage(cached.image);
+            }
+            else
+            {
+                var data = LoadImageData(box.ImageSource);
+                if (data != null)
+                {
+                    box.ImageData = data;
+                    var pdfImage = DecodeImage(box.ImageSource, data);
+                    if (pdfImage != null)
+                        pdfDoc.AddImage(pdfImage);
 
-                // Detect format by magic bytes
-                if (data.Length >= 8 &&
-                    data[0] == 137 && data[1] == 80 && data[2] == 78 && data[3] == 71 &&
-                    data[4] == 13 && data[5] == 10 && data[6] == 26 && data[7] == 10)
-                {
-                    // PNG signature
-                    pdfImage = PdfImage.FromPng(imgName, data);
-                }
-                else if (data.Length >= 2 && data[0] == 0xFF && data[1] == 0xD8)
-                {
-                    // JPEG SOI marker
-                    pdfImage = PdfImage.FromJpeg(imgName, data);
-                }
-                else if (data.Length >= 4 &&
-                    data[0] == 0x47 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x38)
-                {
-                    // GIF signature ("GIF8")
-                    pdfImage = PdfImage.FromGif(imgName, data);
-                }
-                else if (data.Length >= 2 && data[0] == 0x42 && data[1] == 0x4D)
-                {
-                    // BMP signature ("BM")
-                    pdfImage = PdfImage.FromBmp(imgName, data);
-                }
-
-                if (pdfImage != null)
-                {
-                    pdfDoc.AddImage(pdfImage);
+                    if (cacheable)
+                    {
+                        if (DataUriImageCache.Count >= DataUriImageCacheMaxEntries)
+                            DataUriImageCache.Clear(); // crude bound; images are large
+                        DataUriImageCache.TryAdd(box.ImageSource, (data, pdfImage));
+                    }
                 }
             }
         }
 
         foreach (var child in box.Children)
             ResolveImages(child, pdfDoc);
+    }
+
+    /// <summary>Decode raw image bytes into a PdfImage, detecting the format by magic bytes.</summary>
+    private static PdfImage? DecodeImage(string source, byte[] data)
+    {
+        string imgName = "Img" + source.GetHashCode().ToString("X8");
+
+        if (data.Length >= 8 &&
+            data[0] == 137 && data[1] == 80 && data[2] == 78 && data[3] == 71 &&
+            data[4] == 13 && data[5] == 10 && data[6] == 26 && data[7] == 10)
+        {
+            return PdfImage.FromPng(imgName, data); // PNG signature
+        }
+        if (data.Length >= 2 && data[0] == 0xFF && data[1] == 0xD8)
+        {
+            return PdfImage.FromJpeg(imgName, data); // JPEG SOI marker
+        }
+        if (data.Length >= 4 &&
+            data[0] == 0x47 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x38)
+        {
+            return PdfImage.FromGif(imgName, data); // GIF signature ("GIF8")
+        }
+        if (data.Length >= 2 && data[0] == 0x42 && data[1] == 0x4D)
+        {
+            return PdfImage.FromBmp(imgName, data); // BMP signature ("BM")
+        }
+        return null;
     }
 
     /// <summary>Load image data from a source string (data URI or file path).</summary>

--- a/tests/EggPdf.Tests.Unit/Css/CascadePrefilterTests.cs
+++ b/tests/EggPdf.Tests.Unit/Css/CascadePrefilterTests.cs
@@ -1,0 +1,178 @@
+using System.Linq;
+using EggPdf.Css;
+using EggPdf.Css.Cascade;
+using EggPdf.Css.Parser;
+using EggPdf.Html;
+using EggPdf.Html.Dom;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Css;
+
+/// <summary>
+/// The cascade uses a per-rule fast-reject prefilter (rightmost compound's
+/// tag/id/class) before running the full selector matcher. These tests pin
+/// the tricky selector shapes where a wrong prefilter would silently drop
+/// matching rules.
+/// </summary>
+public class CascadePrefilterTests
+{
+    private static HtmlElement Find(HtmlElement root, string tagName, int index = 0)
+    {
+        int seen = 0;
+        HtmlElement? found = null;
+        void Walk(HtmlElement el)
+        {
+            if (found != null) return;
+            if (el.TagName == tagName && seen++ == index) { found = el; return; }
+            foreach (var child in el.ChildNodes.OfType<HtmlElement>()) Walk(child);
+        }
+        Walk(root);
+        found.Should().NotBeNull($"<{tagName}>[{index}] must exist in the test document");
+        return found!;
+    }
+
+    private static ComputedStyle Resolve(string html, string css, string tag, int index = 0)
+    {
+        var doc = HtmlParser.Parse(html);
+        var sheet = CssStyleSheetParser.Parse(css);
+        var resolver = new CascadeResolver(new[] { sheet });
+        return resolver.Resolve(Find(doc.Body!, tag, index), null);
+    }
+
+    [Fact]
+    public void AttributeOnlySelector_StillMatches()
+    {
+        Resolve("<div data-x='1'>t</div>", "[data-x] { color: red; }", "div")
+            .Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void PseudoClassOnlySelector_StillMatches()
+    {
+        Resolve("<div><p>first</p></div>", ":first-child { color: red; }", "p")
+            .Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void UniversalSelector_StillMatches()
+    {
+        Resolve("<span>t</span>", "* { color: red; }", "span")
+            .Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void TagWithPseudoClass_MatchesTagAndRejectsOthers()
+    {
+        var html = "<div><p>a</p><span>b</span></div>";
+        var css = "p:first-child { color: red; }";
+        Resolve(html, css, "p").Color.Should().Be("red");
+        Resolve(html, css, "span").Color.Should().NotBe("red");
+    }
+
+    [Fact]
+    public void ClassSelector_IsCaseInsensitive_LikeTheMatcher()
+    {
+        Resolve("<p class='highlight'>t</p>", ".Highlight { color: red; }", "p")
+            .Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void IdSelector_MatchesAndRejects()
+    {
+        var css = "#main { color: red; }";
+        Resolve("<p id='main'>t</p>", css, "p").Color.Should().Be("red");
+        Resolve("<p id='other'>t</p>", css, "p").Color.Should().NotBe("red");
+    }
+
+    [Fact]
+    public void DescendantSelector_RightmostClassGates()
+    {
+        var html = "<div><span class='inner'>a</span><span>b</span></div>";
+        var css = "div .inner { color: red; }";
+        Resolve(html, css, "span", 0).Color.Should().Be("red");
+        Resolve(html, css, "span", 1).Color.Should().NotBe("red");
+    }
+
+    [Fact]
+    public void CompoundTagClassId_StillMatches()
+    {
+        Resolve("<p class='note' id='x1'>t</p>", "p.note#x1 { color: red; }", "p")
+            .Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void ChildCombinatorWithUniversalRightmost_StillMatches()
+    {
+        Resolve("<div><em>t</em></div>", "div > * { color: red; }", "em")
+            .Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void NotSelector_KeepsTagRequirement()
+    {
+        var html = "<div class='skip'>a</div><div>b</div>";
+        var css = "div:not(.skip) { color: red; }";
+        Resolve(html, css, "div", 1).Color.Should().Be("red");
+        Resolve(html, css, "div", 0).Color.Should().NotBe("red");
+    }
+
+    [Fact]
+    public void AttributeValueWithSpace_DoesNotConfuseCompoundDetection()
+    {
+        Resolve("<p title='a b'>t</p>", "[title='a b'] { color: red; }", "p")
+            .Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void SelectorList_BothPartsMatch()
+    {
+        var css = "h1, .x { color: red; }";
+        Resolve("<h1>t</h1>", css, "h1").Color.Should().Be("red");
+        Resolve("<p class='x'>t</p>", css, "p").Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void GeneralSiblingCombinator_StillMatches()
+    {
+        Resolve("<div><p class='a'>a</p><p class='b'>b</p></div>",
+                ".a ~ .b { color: red; }", "p", 1)
+            .Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void NthChildWithPlusInsideParens_IsNotTreatedAsCombinator()
+    {
+        var html = "<ul><li>1</li><li>2</li><li>3</li></ul>";
+        var css = "li:nth-child(2n+1) { color: red; }";
+        Resolve(html, css, "li", 0).Color.Should().Be("red");
+        Resolve(html, css, "li", 1).Color.Should().NotBe("red");
+        Resolve(html, css, "li", 2).Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void PseudoElement_LegacySingleColon_StillResolves()
+    {
+        var doc = HtmlParser.Parse("<p>t</p>");
+        var sheet = CssStyleSheetParser.Parse("p:before { content: 'x'; color: red; }");
+        var resolver = new CascadeResolver(new[] { sheet });
+        var p = Find(doc.Body!, "p");
+
+        var style = resolver.ResolvePseudoElement(p, "before", null);
+        style.Should().NotBeNull();
+        style!.Color.Should().Be("red");
+    }
+
+    [Fact]
+    public void PseudoElement_DoubleColon_StillResolves_AndMainResolveIgnoresIt()
+    {
+        var doc = HtmlParser.Parse("<p>t</p>");
+        var sheet = CssStyleSheetParser.Parse("p::after { content: 'x'; color: red; }");
+        var resolver = new CascadeResolver(new[] { sheet });
+        var p = Find(doc.Body!, "p");
+
+        resolver.ResolvePseudoElement(p, "after", null)!.Color.Should().Be("red");
+        resolver.Resolve(p, null).Color.Should().NotBe("red",
+            "a pseudo-element rule must not style the element itself");
+    }
+}

--- a/tests/EggPdf.Tests.Unit/Pdf/ImageDecodeCacheTests.cs
+++ b/tests/EggPdf.Tests.Unit/Pdf/ImageDecodeCacheTests.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace EggPdf.Tests.Unit.Pdf;
+
+/// <summary>
+/// data: URI images are decoded once per process (their content is immutable
+/// by construction); file-path images stay uncached because the file can
+/// change on disk between renders.
+/// </summary>
+public class ImageDecodeCacheTests
+{
+    // 1x1 red pixel PNG
+    private const string OnePixelPng =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+    [Fact]
+    public async Task DataUriImage_SecondRender_ReusesDecodedImage()
+    {
+        var html = "<html><body><img src='data:image/png;base64," + OnePixelPng +
+                   "' width='10' height='10'></body></html>";
+
+        await HtmlToPdf.RenderAsync(html); // populate (or hit) the cache
+        int before = HtmlToPdf.ImageCacheHits;
+        var pdf = await HtmlToPdf.RenderAsync(html);
+
+        HtmlToPdf.ImageCacheHits.Should().BeGreaterThan(before,
+            "an identical data: URI must not be base64-decoded and PNG-decoded again");
+        System.Text.Encoding.Latin1.GetString(pdf).Should().Contain("/XObject",
+            "the cached image must still be embedded");
+    }
+}


### PR DESCRIPTION
## Summary
Whole-project performance review (3 parallel subsystem sweeps + manual cascade analysis, 24 findings) with the high-impact / low-risk fixes implemented:

**Style resolution (the dominant render cost — O(rules × elements) with full selector re-parsing):**
- Per-rule **fast-reject prefilter** built at stylesheet load from the rightmost compound's tag/id/class. Extra simple selectors (attributes, pseudo-classes) only narrow a match, so extracted requirements stay sound; class checks may false-positive into the full matcher but can never false-negative. `::` pseudo-element rules skip the main loop entirely.
- **Pseudo-element rule index** by name with precomputed specificity — `ResolvePseudoElement` ran ~6× per element and rescanned *all* author rules (recomputing specificity each time), even with zero pseudo rules in the document.
- Per-element **scratch reuse** (match list + winners dictionary); allocation-free gates for CSS-wide keywords and `var()`/`env()` detection.

**Other hot paths:**
- `ResolveBaseFontName` memoized — it ran per measured word (ToLowerInvariant + ~10 IndexOf scans each time)
- Table row colspan offsets computed once per row (was O(cells²) per row)
- **Bug:** `[ThreadStatic]` table column-width cache never cleared — unbounded growth on pooled threads retaining every past render's DOM; now cleared per render
- HtmlTreeBuilder end-tag fast path (no scratch `Stack` for properly nested closes)
- PDF text runs escape directly into the content stream builder (no temp StringBuilder + string per run); page image de-dup via HashSet
- **data: URI image decode cache** (process-wide, capped) — immutable by construction; file paths deliberately stay uncached since files can change on disk

## Test evidence
- Unit: **1005/1005** (17 new: 15 cascade-prefilter regressions pinning tricky selector shapes — attribute-only, `:nth-child(2n+1)`, selector lists, sibling combinators, case-insensitivity, legacy `:before` — plus pseudo-element resolution and image-cache tests)
- Layout: **554/554**

## Perf evidence (same machine, back-to-back vs main)
| Scenario | Allocations (exact) | Time |
|---|---|---|
| Simple page | 36.4 → **33.8 KB (−7%)** | within noise |
| Invoice | 344.7 → **268.3 KB (−22%)** | −6% (within error) |
| Large table | 1679.9 → **1247.4 KB (−26%)** | **9.3 → 5.5 ms (−41%)** on the calm run |

Time measurements carry large error bars (busy machine); allocation numbers are exact and machine-independent.

## Reviewed, deferred (documented for future passes)
Flex auto-item triple-measurement, span-based PDF number formatting (~40 emit sites), O(pages×boxes) pagination rescans, renderer collector-walk merge, PNG per-pixel bit-depth branch hoisting, inline-style parse memoization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)