### PR TITLE
fix: detect indirect /Encrypt refs and sub-dict /FlateDecode in merger/signer

### DIFF
--- a/src/EggPdf.Pdf/PdfInspect.cs
+++ b/src/EggPdf.Pdf/PdfInspect.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Text;
+
+namespace EggPdf.Pdf;
+
+/// <summary>Lightweight structural probes over raw PDF bytes.</summary>
+internal static class PdfInspect
+{
+    private static readonly Encoding Latin1 = Encoding.GetEncoding(28591);
+
+    /// <summary>
+    /// True if the PDF declares an /Encrypt entry, whether written as a direct
+    /// dictionary (/Encrypt &lt;&lt; ... &gt;&gt;) or an indirect reference
+    /// (/Encrypt 12 0 R). Substring matching on "/Encrypt &lt;&lt;" alone misses
+    /// the indirect form, which is what most non-EggPdf writers emit.
+    /// </summary>
+    public static bool IsEncrypted(byte[] pdf)
+    {
+        if (pdf == null || pdf.Length == 0) return false;
+        var text = Latin1.GetString(pdf);
+
+        int idx = 0;
+        while ((idx = text.IndexOf("/Encrypt", idx, StringComparison.Ordinal)) >= 0)
+        {
+            int p = idx + "/Encrypt".Length;
+            // Skip whitespace after the key.
+            while (p < text.Length && (text[p] == ' ' || text[p] == '\r' || text[p] == '\n' || text[p] == '\t'))
+                p++;
+            if (p < text.Length)
+            {
+                char c = text[p];
+                // Direct dict "<<" or indirect reference "N 0 R" (starts with a digit).
+                if ((c == '<' && p + 1 < text.Length && text[p + 1] == '<') ||
+                    (c >= '0' && c <= '9'))
+                    return true;
+            }
+            idx = p;
+        }
+        return false;
+    }
+}

--- a/src/EggPdf.Pdf/PdfMerger.cs
+++ b/src/EggPdf.Pdf/PdfMerger.cs
@@ -56,7 +56,7 @@ public class PdfMerger
         {
             // Encrypted inputs cannot be merged: their stream bytes are
             // ciphertext and would be re-emitted as garbage page operators.
-            if (Encoding.ASCII.GetString(doc).IndexOf("/Encrypt <<", StringComparison.Ordinal) >= 0)
+            if (PdfInspect.IsEncrypted(doc))
                 throw new NotSupportedException(
                     "Merging encrypted PDFs is not supported — decrypt or re-render the input first.");
 
@@ -121,9 +121,13 @@ public class PdfMerger
                 var body = new byte[bodyEnd - streamIdx];
                 Array.Copy(pdf, streamIdx, body, 0, body.Length);
 
-                // The stream's dictionary immediately precedes "stream\n"
-                int dictStart = Math.Max(0, text.LastIndexOf("<<", streamIdx, StringComparison.Ordinal));
-                bool compressed = text.IndexOf("/FlateDecode", dictStart, streamIdx - dictStart, StringComparison.Ordinal) >= 0;
+                // Scan the whole containing object dict (from "N 0 obj" to the
+                // stream) so a nested sub-dictionary — e.g. /DecodeParms << ... >>
+                // — can't hide the /FlateDecode token. Anchoring on the nearest
+                // "<<" would stop at the inner sub-dict.
+                int objStart = text.LastIndexOf(" obj", streamIdx, StringComparison.Ordinal);
+                if (objStart < 0) objStart = 0;
+                bool compressed = text.IndexOf("/FlateDecode", objStart, streamIdx - objStart, StringComparison.Ordinal) >= 0;
                 if (compressed)
                 {
                     try { body = InflateZlib(body); }

--- a/src/EggPdf.Pdf/PdfSigner.cs
+++ b/src/EggPdf.Pdf/PdfSigner.cs
@@ -183,7 +183,7 @@ public static class PdfSigner
     /// </summary>
     private static void ThrowIfEncrypted(byte[] pdfBytes)
     {
-        if (Encoding.ASCII.GetString(pdfBytes).IndexOf("/Encrypt <<", StringComparison.Ordinal) >= 0)
+        if (PdfInspect.IsEncrypted(pdfBytes))
             throw new NotSupportedException(
                 "Signing an encrypted PDF is not supported — sign first, then note that " +
                 "encrypting afterwards invalidates the signature; use one or the other.");

--- a/tests/EggPdf.Tests.Unit/Pdf/PdfMergerTests.cs
+++ b/tests/EggPdf.Tests.Unit/Pdf/PdfMergerTests.cs
@@ -63,4 +63,54 @@ public class PdfMergerTests
         act.Should().Throw<NotSupportedException>(
             "merging encrypted PDFs would silently re-emit ciphertext as page operators");
     }
+
+    [Fact]
+    public void Merge_ForeignPdf_IndirectEncryptReference_IsRefused()
+    {
+        // Most non-EggPdf writers reference the encryption dict indirectly
+        // ("/Encrypt 9 0 R") rather than inline — the guard must catch it.
+        var foreign = System.Text.Encoding.ASCII.GetBytes(
+            "%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n" +
+            "trailer\n<< /Root 1 0 R /Encrypt 9 0 R /ID [<00> <00>] >>\n%%EOF");
+        var merger = new PdfMerger();
+        merger.Add(foreign);
+        merger.Add(MakePdf("plain", compress: false));
+
+        var act = () => merger.Build();
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void Merge_StreamDictWithSubDictionary_StillInflates()
+    {
+        // A stream whose dict contains a nested sub-dictionary before the
+        // /FlateDecode token must still be detected as compressed.
+        var doc = new PdfDocument { CompressContentStreams = true };
+        var page = doc.AddPage(595, 842);
+        page.AddText("nested dict content", 50, 700, "Helvetica", 12);
+        var bytes = doc.ToByteArray();
+
+        // Inject a /DecodeParms sub-dict AFTER /FlateDecode, so the nearest
+        // "<<" before the stream is the sub-dict's — the exact shape that
+        // defeats a LastIndexOf("<<") scan (the token is now outside its
+        // window). Anchoring on the object start must still find it.
+        var text = System.Text.Encoding.Latin1.GetString(bytes);
+        text = ReplaceFirst(text, "/Filter /FlateDecode",
+            "/Filter /FlateDecode /DecodeParms << /Predictor 1 >>");
+        var mutated = System.Text.Encoding.Latin1.GetBytes(text);
+
+        var merger = new PdfMerger();
+        merger.Add(mutated);
+        merger.Add(MakePdf("second page", compress: false));
+
+        System.Text.Encoding.Latin1.GetString(merger.Build())
+            .Should().Contain("(nested dict content) Tj",
+                "the /FlateDecode after a sub-dict must still trigger inflation");
+    }
+
+    private static string ReplaceFirst(string haystack, string find, string replace)
+    {
+        int i = haystack.IndexOf(find, StringComparison.Ordinal);
+        return i < 0 ? haystack : haystack.Substring(0, i) + replace + haystack.Substring(i + find.Length);
+    }
 }


### PR DESCRIPTION
## Summary
A self-review of my own round-2 fixes (PR #215) found both new guards were only tested against EggPdf's *own* output and silently failed for **foreign** PDFs — exactly the inputs merge/sign exist to accept.

- **Encrypted-input guards missed indirect `/Encrypt` references.** They matched the literal `/Encrypt <<`, but most non-EggPdf writers reference the encryption dict indirectly (`/Encrypt 12 0 R`). A foreign encrypted PDF therefore flowed through merge/sign and got corrupted — the very outcome the guard claimed to prevent. Replaced with a shared `PdfInspect.IsEncrypted` that matches both the direct dict and the indirect reference (`/Encrypt` + whitespace + `<<` or a digit).
- **Merger `/FlateDecode` detection was defeated by a stream sub-dictionary.** It anchored the scan on the nearest `<<` before the stream, which is the *inner* `<<` when the dict contains e.g. `/DecodeParms << ... >>` after `/Filter`. The `/FlateDecode` token then fell outside the window, so compressed bytes were emitted raw. Now anchors on the containing object start (`" obj"`).

Both defects were latent for self-produced PDFs (direct `/Encrypt`, flat stream dicts), which is why round-2's tests passed while missing them.

## Test evidence
- Unit: **1017/1017** (2 new: indirect-`/Encrypt` trailer refused; `/DecodeParms` sub-dict after `/FlateDecode` still inflates — both fail on the pre-fix code)
- Layout: **554/554**

## Still deferred (unchanged)
Foreign PDFs remain best-effort in merge (no full object-graph parse) — but they now fail loudly on encryption instead of producing garbage. Signature AcroForm wiring still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)