### PR TITLE
fix: merger resolves page /Contents refs instead of Nth stream in file order

### DIFF
--- a/src/EggPdf.Pdf/PdfMerger.cs
+++ b/src/EggPdf.Pdf/PdfMerger.cs
@@ -60,35 +60,105 @@ public class PdfMerger
                 throw new NotSupportedException(
                     "Merging encrypted PDFs is not supported — decrypt or re-render the input first.");
 
-            // Extract pages from each document
-            // Simple approach: find page content streams and re-emit
-            int pageCount = CountPages(doc);
-            for (int i = 0; i < pageCount; i++)
+            // Resolve each page dictionary to the content stream it actually
+            // references. Taking the Nth stream in file order would pick up
+            // font programs and images, which are written before page content.
+            var text = Latin1.GetString(doc);
+            var pages = FindPages(text);
+            foreach (var pageRef in pages)
             {
-                var pageContent = ExtractPageContent(doc, i);
-                var pageSize = ExtractPageSize(doc);
-                var page = output.AddPage(pageSize.width, pageSize.height);
-                if (pageContent != null)
-                    page.AppendRawContent(pageContent);
+                var page = output.AddPage(pageRef.Width, pageRef.Height);
+                var content = pageRef.ContentObj > 0
+                    ? ExtractObjectStream(doc, text, pageRef.ContentObj)
+                    : null;
+                if (content != null)
+                    page.AppendRawContent(content);
             }
         }
 
         return output.ToByteArray();
     }
 
-    /// <summary>Count pages in a PDF by counting /Type /Page objects.</summary>
-    private static int CountPages(byte[] pdf)
+    /// <summary>A page dictionary's content-stream reference and dimensions.</summary>
+    private struct PageRef
     {
-        var text = Encoding.ASCII.GetString(pdf);
-        int count = 0;
+        public int ContentObj;
+        public float Width;
+        public float Height;
+    }
+
+    /// <summary>
+    /// Locate every page dictionary (/Type /Page, not the /Pages tree node)
+    /// and read its /Contents object number and /MediaBox.
+    /// </summary>
+    private static List<PageRef> FindPages(string text)
+    {
+        var pages = new List<PageRef>();
         int idx = 0;
-        while ((idx = text.IndexOf("/Type /Page ", idx, StringComparison.Ordinal)) >= 0)
+        while ((idx = text.IndexOf("/Type /Page", idx, StringComparison.Ordinal)) >= 0)
         {
-            // Make sure it's /Page not /Pages
-            count++;
-            idx += 12;
+            int after = idx + "/Type /Page".Length;
+            // "/Type /Pages" is the page-tree node, not a page.
+            if (after < text.Length && text[after] == 's')
+            {
+                idx = after;
+                continue;
+            }
+
+            int endObj = text.IndexOf("endobj", idx, StringComparison.Ordinal);
+            if (endObj < 0) endObj = text.Length;
+
+            pages.Add(new PageRef
+            {
+                ContentObj = ParseIndirectRef(text, idx, endObj, "/Contents"),
+                Width = ParseMediaBox(text, idx, endObj).width,
+                Height = ParseMediaBox(text, idx, endObj).height,
+            });
+            idx = endObj;
         }
-        return Math.Max(count, 1);
+        return pages;
+    }
+
+    /// <summary>Parse "/Key N 0 R" within a range; returns 0 when absent.</summary>
+    private static int ParseIndirectRef(string text, int start, int end, string key)
+    {
+        int keyIdx = text.IndexOf(key, start, end - start, StringComparison.Ordinal);
+        if (keyIdx < 0) return 0;
+        int p = keyIdx + key.Length;
+        while (p < end && text[p] == ' ') p++;
+        int numStart = p;
+        while (p < end && text[p] >= '0' && text[p] <= '9') p++;
+        if (p == numStart) return 0; // inline array or direct object, not a ref
+        return int.TryParse(text.Substring(numStart, p - numStart), out int objNum) ? objNum : 0;
+    }
+
+    /// <summary>Parse "/MediaBox [x0 y0 x1 y1]" within a range; A4 when absent.</summary>
+    private static (float width, float height) ParseMediaBox(string text, int start, int end)
+    {
+        int mbIdx = text.IndexOf("/MediaBox", start, end - start, StringComparison.Ordinal);
+        if (mbIdx >= 0)
+        {
+            int bracketStart = text.IndexOf('[', mbIdx);
+            int bracketEnd = bracketStart >= 0 ? text.IndexOf(']', bracketStart) : -1;
+            if (bracketStart >= 0 && bracketEnd > bracketStart)
+            {
+                var coords = text.Substring(bracketStart + 1, bracketEnd - bracketStart - 1)
+                    .Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (coords.Length >= 4 &&
+                    float.TryParse(coords[0], System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out float x0) &&
+                    float.TryParse(coords[1], System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out float y0) &&
+                    float.TryParse(coords[2], System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out float x1) &&
+                    float.TryParse(coords[3], System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out float y1))
+                {
+                    return (Math.Abs(x1 - x0), Math.Abs(y1 - y0));
+                }
+            }
+        }
+        return (595.28f, 841.89f); // A4 in points
     }
 
     /// <summary>
@@ -97,50 +167,54 @@ public class PdfMerger
     /// inflating; scanning uses Latin-1 (1:1 char-to-byte) and the body is
     /// sliced from the original bytes so compressed data survives intact.
     /// </summary>
-    private static string? ExtractPageContent(byte[] pdf, int pageIndex)
+    private static string? ExtractObjectStream(byte[] pdf, string text, int objNum)
     {
-        var text = Latin1.GetString(pdf);
-        int streamIdx = 0;
-        int page = 0;
+        // Anchor on a line-start "N 0 obj" so object 1 doesn't match "21 0 obj".
+        int objStart = FindObjectStart(text, objNum);
+        if (objStart < 0) return null;
 
-        while (streamIdx < text.Length)
+        int streamIdx = text.IndexOf("stream\n", objStart, StringComparison.Ordinal);
+        if (streamIdx < 0) return null;
+        int endObj = text.IndexOf("endobj", objStart, StringComparison.Ordinal);
+        if (endObj >= 0 && streamIdx > endObj) return null; // object has no stream
+        streamIdx += "stream\n".Length;
+
+        int endIdx = text.IndexOf("endstream", streamIdx, StringComparison.Ordinal);
+        if (endIdx < 0) return null;
+
+        int bodyEnd = endIdx;
+        while (bodyEnd > streamIdx && (text[bodyEnd - 1] == '\n' || text[bodyEnd - 1] == '\r'))
+            bodyEnd--;
+
+        var body = new byte[bodyEnd - streamIdx];
+        Array.Copy(pdf, streamIdx, body, 0, body.Length);
+
+        // Scan the whole object dict (from "N 0 obj" to the stream) so a nested
+        // sub-dictionary — e.g. /DecodeParms << ... >> — can't hide the
+        // /FlateDecode token; the nearest "<<" would stop at the inner dict.
+        bool compressed = text.IndexOf("/FlateDecode", objStart, streamIdx - objStart,
+            StringComparison.Ordinal) >= 0;
+        if (compressed)
         {
-            streamIdx = text.IndexOf("stream\n", streamIdx, StringComparison.Ordinal);
-            if (streamIdx < 0) break;
-            streamIdx += 7;
-
-            int endIdx = text.IndexOf("endstream", streamIdx, StringComparison.Ordinal);
-            if (endIdx < 0) break;
-
-            if (page == pageIndex)
-            {
-                int bodyEnd = endIdx;
-                while (bodyEnd > streamIdx && (text[bodyEnd - 1] == '\n' || text[bodyEnd - 1] == '\r'))
-                    bodyEnd--;
-
-                var body = new byte[bodyEnd - streamIdx];
-                Array.Copy(pdf, streamIdx, body, 0, body.Length);
-
-                // Scan the whole containing object dict (from "N 0 obj" to the
-                // stream) so a nested sub-dictionary — e.g. /DecodeParms << ... >>
-                // — can't hide the /FlateDecode token. Anchoring on the nearest
-                // "<<" would stop at the inner sub-dict.
-                int objStart = text.LastIndexOf(" obj", streamIdx, StringComparison.Ordinal);
-                if (objStart < 0) objStart = 0;
-                bool compressed = text.IndexOf("/FlateDecode", objStart, streamIdx - objStart, StringComparison.Ordinal) >= 0;
-                if (compressed)
-                {
-                    try { body = InflateZlib(body); }
-                    catch { return null; } // undecodable stream: skip the page content
-                }
-                return Latin1.GetString(body);
-            }
-
-            page++;
-            streamIdx = endIdx + 9;
+            try { body = InflateZlib(body); }
+            catch { return null; } // undecodable stream: skip this page's content
         }
+        return Latin1.GetString(body);
+    }
 
-        return null;
+    /// <summary>Find the offset of "N 0 obj" at a line start for the given object number.</summary>
+    private static int FindObjectStart(string text, int objNum)
+    {
+        string marker = objNum.ToString(System.Globalization.CultureInfo.InvariantCulture) + " 0 obj";
+        int idx = 0;
+        while ((idx = text.IndexOf(marker, idx, StringComparison.Ordinal)) >= 0)
+        {
+            // Must begin a line, otherwise "1 0 obj" matches inside "21 0 obj".
+            if (idx == 0 || text[idx - 1] == '\n' || text[idx - 1] == '\r')
+                return idx;
+            idx += marker.Length;
+        }
+        return -1;
     }
 
     private static readonly Encoding Latin1 = Encoding.GetEncoding(28591);
@@ -155,28 +229,4 @@ public class PdfMerger
         return output.ToArray();
     }
 
-    /// <summary>Extract page dimensions from MediaBox.</summary>
-    private static (float width, float height) ExtractPageSize(byte[] pdf)
-    {
-        var text = Encoding.ASCII.GetString(pdf);
-        int mbIdx = text.IndexOf("/MediaBox", StringComparison.Ordinal);
-        if (mbIdx >= 0)
-        {
-            int bracketStart = text.IndexOf('[', mbIdx);
-            int bracketEnd = text.IndexOf(']', bracketStart);
-            if (bracketStart >= 0 && bracketEnd >= 0)
-            {
-                var coords = text.Substring(bracketStart + 1, bracketEnd - bracketStart - 1).Trim().Split(' ');
-                if (coords.Length >= 4)
-                {
-                    float.TryParse(coords[2], System.Globalization.NumberStyles.Float,
-                        System.Globalization.CultureInfo.InvariantCulture, out float w);
-                    float.TryParse(coords[3], System.Globalization.NumberStyles.Float,
-                        System.Globalization.CultureInfo.InvariantCulture, out float h);
-                    return (w, h);
-                }
-            }
-        }
-        return (595.28f * 0.75f, 841.89f * 0.75f); // Default A4
-    }
 }

--- a/tests/EggPdf.Tests.Unit/Pdf/PdfMergerTests.cs
+++ b/tests/EggPdf.Tests.Unit/Pdf/PdfMergerTests.cs
@@ -6,10 +6,11 @@ using Xunit;
 namespace EggPdf.Tests.Unit.Pdf;
 
 /// <summary>
-/// PdfMerger must handle inputs produced with the production default of
-/// FlateDecode-compressed content streams (it extracts and re-emits page
-/// operators), and must refuse encrypted inputs instead of silently
-/// producing ciphertext pages.
+/// PdfMerger must resolve each page dictionary to the content stream it
+/// actually references (font programs and images are written before page
+/// content, so file order is meaningless), handle inputs produced with the
+/// production default of FlateDecode-compressed content streams, and refuse
+/// encrypted inputs instead of silently producing ciphertext pages.
 /// </summary>
 public class PdfMergerTests
 {
@@ -21,15 +22,16 @@ public class PdfMergerTests
         return doc.ToByteArray();
     }
 
+    private static string Latin1(byte[] pdf) => System.Text.Encoding.Latin1.GetString(pdf);
+
     [Fact]
     public void Merge_UncompressedInputs_KeepsBothPagesText()
     {
         var merger = new PdfMerger();
         merger.Add(MakePdf("first document", compress: false));
         merger.Add(MakePdf("second document", compress: false));
-        var merged = merger.Build();
 
-        var text = System.Text.Encoding.Latin1.GetString(merged);
+        var text = Latin1(merger.Build());
         text.Should().Contain("(first document) Tj");
         text.Should().Contain("(second document) Tj");
     }
@@ -38,15 +40,12 @@ public class PdfMergerTests
     public void Merge_CompressedInputs_InflatesAndKeepsBothPagesText()
     {
         // Production renders compress content streams by default — the merger
-        // must inflate them, not copy ciphertext as if it were operators.
+        // must inflate them, not copy compressed bytes as if they were operators.
         var merger = new PdfMerger();
         merger.Add(MakePdf("first compressed", compress: true));
         merger.Add(MakePdf("second compressed", compress: true));
-        var merged = merger.Build();
 
-        // The test assembly writes merged output uncompressed (TestSetup),
-        // so recovered operators are directly visible.
-        var text = System.Text.Encoding.Latin1.GetString(merged);
+        var text = Latin1(merger.Build());
         text.Should().Contain("(first compressed) Tj");
         text.Should().Contain("(second compressed) Tj");
     }
@@ -83,19 +82,14 @@ public class PdfMergerTests
     [Fact]
     public void Merge_StreamDictWithSubDictionary_StillInflates()
     {
-        // A stream whose dict contains a nested sub-dictionary before the
-        // /FlateDecode token must still be detected as compressed.
         var doc = new PdfDocument { CompressContentStreams = true };
         var page = doc.AddPage(595, 842);
         page.AddText("nested dict content", 50, 700, "Helvetica", 12);
-        var bytes = doc.ToByteArray();
 
         // Inject a /DecodeParms sub-dict AFTER /FlateDecode, so the nearest
-        // "<<" before the stream is the sub-dict's — the exact shape that
-        // defeats a LastIndexOf("<<") scan (the token is now outside its
-        // window). Anchoring on the object start must still find it.
-        var text = System.Text.Encoding.Latin1.GetString(bytes);
-        text = ReplaceFirst(text, "/Filter /FlateDecode",
+        // "<<" before the stream is the sub-dict's — the shape that defeats a
+        // LastIndexOf("<<") scan. Anchoring on the object start still finds it.
+        var text = ReplaceFirst(Latin1(doc.ToByteArray()), "/Filter /FlateDecode",
             "/Filter /FlateDecode /DecodeParms << /Predictor 1 >>");
         var mutated = System.Text.Encoding.Latin1.GetBytes(text);
 
@@ -103,9 +97,62 @@ public class PdfMergerTests
         merger.Add(mutated);
         merger.Add(MakePdf("second page", compress: false));
 
-        System.Text.Encoding.Latin1.GetString(merger.Build())
-            .Should().Contain("(nested dict content) Tj",
-                "the /FlateDecode after a sub-dict must still trigger inflation");
+        Latin1(merger.Build()).Should().Contain("(nested dict content) Tj",
+            "a /FlateDecode before a sub-dict must still trigger inflation");
+    }
+
+    [Fact]
+    public void Merge_RealRendersWithEmbeddedFonts_RecoversPageContentNotFontData()
+    {
+        // Real renders write font programs and ToUnicode CMaps BEFORE page
+        // content streams, so selecting the Nth stream in file order yields
+        // font data instead of page operators. The merger must follow each
+        // page's /Contents reference.
+        var first = HtmlToPdf.Render("<html><body><p>Giấy Chứng Nhận số một</p></body></html>");
+        var second = HtmlToPdf.Render("<html><body><p>Trang thứ hai</p></body></html>");
+
+        Latin1(first).Should().Contain("/FontFile2",
+            "the input must embed a font, which is what shifts stream order");
+
+        var text = Latin1(new PdfMerger().Add(first).Add(second).Build());
+
+        // Vietnamese renders through CID fonts as glyph IDs, so assert on the
+        // recovered operators rather than the literal characters.
+        text.Should().Contain("BT", "merged pages must carry real text operators");
+        text.Should().Contain("Tf", "a font must be selected in the merged content");
+        text.Should().Contain("Tj", "glyphs must be shown");
+    }
+
+    [Fact]
+    public void Merge_PagesOfDifferentSizes_KeepsEachPageOwnMediaBox()
+    {
+        // Page size was previously read once from the first /MediaBox in the
+        // document and applied to every page of it — so the sizes must differ
+        // WITHIN a single input document for this to pin the bug.
+        var mixed = new PdfDocument();
+        mixed.AddPage(595.28f, 841.89f).AddText("a4 page", 50, 700, "Helvetica", 12);
+        mixed.AddPage(612f, 792f).AddText("letter page", 50, 700, "Helvetica", 12);
+
+        var text = Latin1(new PdfMerger().Add(mixed.ToByteArray()).Add(MakePdf("tail", false)).Build());
+
+        text.Should().Contain("/MediaBox [0 0 595.28 841.89]");
+        text.Should().Contain("/MediaBox [0 0 612.00 792.00]");
+    }
+
+    [Fact]
+    public void Merge_MultiPageDocument_KeepsEveryPage()
+    {
+        var multi = new PdfDocument();
+        multi.AddPage(595, 842).AddText("page one", 50, 700, "Helvetica", 12);
+        multi.AddPage(595, 842).AddText("page two", 50, 700, "Helvetica", 12);
+        multi.AddPage(595, 842).AddText("page three", 50, 700, "Helvetica", 12);
+
+        var text = Latin1(new PdfMerger().Add(multi.ToByteArray()).Add(MakePdf("tail", false)).Build());
+
+        text.Should().Contain("(page one) Tj");
+        text.Should().Contain("(page two) Tj");
+        text.Should().Contain("(page three) Tj");
+        text.Should().Contain("(tail) Tj");
     }
 
     private static string ReplaceFirst(string haystack, string find, string replace)


### PR DESCRIPTION
## Summary
Found by extending the merger tests past trivial documents: **`PdfMerger` was broken for any PDF containing an embedded font or image.**

It selected the Nth `stream` in file order as page N's content. But real renders write font programs (`FontFile2`), ToUnicode CMaps, and image XObjects *before* page content streams — so merging a normal `HtmlToPdf.Render` output produced pages containing compressed **font data**, and the merged file had no text operators at all. It only ever worked for documents using built-in Type1 fonts, which is precisely what every existing merger test used.

Also fixed alongside: `/MediaBox` was read once per *document* and applied to all its pages, so a document mixing page sizes lost them after merge.

Now: page dictionaries are located (`/Type /Page`, excluding the `/Pages` tree node), each one's `/Contents` object number is resolved, and that object's stream is extracted and inflated. Object lookup anchors on a line-start `N 0 obj` so object `1` doesn't match inside `21 0 obj`.

## Test evidence
- Unit: **1020/1020** (3 new merger tests; **2 of them fail on the pre-fix code** — verified by stashing the fix and re-running: the real-render test and the mixed-page-size test)
- Layout: **554/554**
- Also verified out-of-band that a real 100KB certificate render (compressed streams, CID fonts, images) contains no `/Encrypt` false-positive trigger for the round-3 guard.

## Note on scope
This is the third distinct defect in `PdfMerger`, all of the same shape: it was written against trivial self-produced PDFs and pattern-matches raw bytes rather than parsing the object graph. It is now correct for EggPdf output and reasonable foreign PDFs, but it still does not resolve `/Contents` arrays, inherited page attributes, or object streams. A real object-graph parser is the durable fix if merging becomes a first-class feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)